### PR TITLE
fix space required after regex operator

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -2549,7 +2549,6 @@ func (p *Parser) ParseExpr() (Expr, error) {
 		var rhs Expr
 		if IsRegexOp(op) {
 			// RHS of a regex operator must be a regular expression.
-			p.consumeWhitespace()
 			if rhs, err = p.parseRegex(); err != nil {
 				return nil, err
 			}

--- a/parser_test.go
+++ b/parser_test.go
@@ -3634,6 +3634,16 @@ func TestParser_ParseExpr(t *testing.T) {
 			},
 		},
 
+		// Binary expression with quoted '/' regex without space around operator. Influxdb #9058
+		{
+			s: `url=~/http\:\/\/www\.example\.com/`,
+			expr: &influxql.BinaryExpr{
+				Op:  influxql.EQREGEX,
+				LHS: &influxql.VarRef{Val: "url"},
+				RHS: &influxql.RegexLiteral{Val: regexp.MustCompile(`http\://www\.example\.com`)},
+			},
+		},
+
 		// Complex binary expression.
 		{
 			s: `value + 3 < 30 AND 1 + 2 OR true`,


### PR DESCRIPTION
Fix for this issue: https://github.com/influxdata/influxdb/issues/9058
Removed p.consumeWhitespace() when parsing expression and added a test