### PR TITLE
Reduce the results of ConditionExpr

### DIFF
--- a/ast.go
+++ b/ast.go
@@ -5185,11 +5185,11 @@ func ConditionExpr(cond Expr, valuer Valuer) (Expr, TimeRange, error) {
 			} else if lhsExpr == nil {
 				return rhsExpr, timeRange, nil
 			}
-			return &BinaryExpr{
+			return Reduce(&BinaryExpr{
 				Op:  cond.Op,
 				LHS: lhsExpr,
 				RHS: rhsExpr,
-			}, timeRange, nil
+			}, nil), timeRange, nil
 		}
 
 		// If either the left or the right side is "time", we are looking at
@@ -5213,7 +5213,7 @@ func ConditionExpr(cond Expr, valuer Valuer) (Expr, TimeRange, error) {
 			timeRange, err := getTimeRange(op, cond.LHS, valuer)
 			return nil, timeRange, err
 		}
-		return cond, TimeRange{}, nil
+		return Reduce(cond, nil), TimeRange{}, nil
 	case *ParenExpr:
 		expr, timeRange, err := ConditionExpr(cond.Expr, valuer)
 		if err != nil {
@@ -5221,7 +5221,7 @@ func ConditionExpr(cond Expr, valuer Valuer) (Expr, TimeRange, error) {
 		} else if expr == nil {
 			return nil, timeRange, nil
 		}
-		return &ParenExpr{Expr: expr}, timeRange, nil
+		return Reduce(&ParenExpr{Expr: expr}, nil), timeRange, nil
 	case *BooleanLiteral:
 		return cond, TimeRange{}, nil
 	default:

--- a/ast_test.go
+++ b/ast_test.go
@@ -748,10 +748,10 @@ func TestConditionExpr(t *testing.T) {
 			min: mustParseTime("2000-01-01T00:00:00Z"),
 			max: mustParseTime("2000-01-01T01:00:00Z").Add(-1)},
 		{s: `host = 'server01' AND (region = 'uswest' AND time >= now() - 10m)`,
-			cond: `host = 'server01' AND (region = 'uswest')`,
+			cond: `host = 'server01' AND region = 'uswest'`,
 			min:  mustParseTime("1999-12-31T23:50:00Z")},
 		{s: `(host = 'server01' AND region = 'uswest') AND time >= now() - 10m`,
-			cond: `(host = 'server01' AND region = 'uswest')`,
+			cond: `host = 'server01' AND region = 'uswest'`,
 			min:  mustParseTime("1999-12-31T23:50:00Z")},
 		{s: `host = 'server01' AND (time >= '2000-01-01T00:00:00Z' AND time < '2000-01-01T01:00:00Z')`,
 			cond: `host = 'server01'`,
@@ -795,8 +795,9 @@ func TestConditionExpr(t *testing.T) {
 		{s: `time > '2262-04-11 23:47:17'`, err: `time 2262-04-11T23:47:17Z overflows time literal`},
 		{s: `time > '1677-09-20 19:12:43'`, err: `time 1677-09-20T19:12:43Z underflows time literal`},
 		{s: `true AND (false OR product = 'xyz')`,
-			cond: `true AND (false OR product = 'xyz')`,
+			cond: `product = 'xyz'`,
 		},
+		{s: `'a' = 'a'`, cond: `true`},
 	} {
 		t.Run(tt.s, func(t *testing.T) {
 			expr, err := influxql.ParseExpr(tt.s)


### PR DESCRIPTION
This allows literals to be evaluated within the condition expression.

Fixes influxdata/influxdb#9290.