### PR TITLE
The stddev() call always returns a float

### DIFF
--- a/ast.go
+++ b/ast.go
@@ -4326,7 +4326,7 @@ func EvalType(expr Expr, sources Sources, typmap TypeMapper) DataType {
 		return typ
 	case *Call:
 		switch expr.Name {
-		case "mean", "median", "integral":
+		case "mean", "median", "integral", "stddev":
 			return Float
 		case "count":
 			return Integer

--- a/ast_test.go
+++ b/ast_test.go
@@ -1127,6 +1127,16 @@ func TestEvalType(t *testing.T) {
 			},
 		},
 		{
+			name: `stddev() with an integer`,
+			in:   `stddev(value)`,
+			typ:  influxql.Float,
+			data: EvalFixture{
+				"cpu": map[string]influxql.DataType{
+					"value": influxql.Integer,
+				},
+			},
+		},
+		{
 			name: `value inside a parenthesis`,
 			in:   `(value)`,
 			typ:  influxql.Float,


### PR DESCRIPTION
Fixes influxdata/influxdb#9386.