### PR TITLE
Allow the time literal to be uppercase

### DIFF
--- a/ast.go
+++ b/ast.go
@@ -5204,10 +5204,10 @@ func conditionExpr(cond Expr, valuer Valuer) (Expr, TimeRange, error) {
 
 		// If either the left or the right side is "time", we are looking at
 		// a time range.
-		if lhs, ok := cond.LHS.(*VarRef); ok && lhs.Val == "time" {
+		if lhs, ok := cond.LHS.(*VarRef); ok && strings.ToLower(lhs.Val) == "time" {
 			timeRange, err := getTimeRange(cond.Op, cond.RHS, valuer)
 			return nil, timeRange, err
-		} else if rhs, ok := cond.RHS.(*VarRef); ok && rhs.Val == "time" {
+		} else if rhs, ok := cond.RHS.(*VarRef); ok && strings.ToLower(rhs.Val) == "time" {
 			// Swap the op for the opposite if it is a comparison.
 			op := cond.Op
 			switch op {

--- a/ast_test.go
+++ b/ast_test.go
@@ -800,6 +800,8 @@ func TestConditionExpr(t *testing.T) {
 		{s: `'a' = 'a'`, cond: ``},
 		{s: `value > 0 OR true`, cond: ``},
 		{s: `host = 'server01' AND false`, cond: `false`},
+		{s: `TIME >= '2000-01-01T00:00:00Z'`, min: mustParseTime("2000-01-01T00:00:00Z")},
+		{s: `'2000-01-01T00:00:00Z' <= TIME`, min: mustParseTime("2000-01-01T00:00:00Z")},
 	} {
 		t.Run(tt.s, func(t *testing.T) {
 			expr, err := influxql.ParseExpr(tt.s)


### PR DESCRIPTION
Fixes influxdata/influxdb#9533.