### PR TITLE
Fix the ConditionExpr function to account for operator precedence

### DIFF
--- a/ast_test.go
+++ b/ast_test.go
@@ -825,6 +825,8 @@ func TestConditionExpr(t *testing.T) {
 		{s: `host = 'server01' AND false`, cond: `false`},
 		{s: `TIME >= '2000-01-01T00:00:00Z'`, min: mustParseTime("2000-01-01T00:00:00Z")},
 		{s: `'2000-01-01T00:00:00Z' <= TIME`, min: mustParseTime("2000-01-01T00:00:00Z")},
+		{s: `(host = 'server01' OR host = 'server02') AND region = 'uswest'`,
+			cond: `(host = 'server01' OR host = 'server02') AND region = 'uswest'`},
 	} {
 		t.Run(tt.s, func(t *testing.T) {
 			expr, err := influxql.ParseExpr(tt.s)


### PR DESCRIPTION
It will now add parenthesis when needed to keep precedence rules
compatible. This way, the AST output can be stringified and then
reparsed without losing the structure.

This also automatically unrolls all parenthesis now and then rewraps
them when needed because the previous implementation looked like it
retained parenthesis, but they would always be stripped anyway.