### PR TITLE
update system names for measurements and tag keys

### DIFF
--- a/ast.go
+++ b/ast.go
@@ -523,7 +523,9 @@ func IsSystemName(name string) bool {
 	switch name {
 	case "_fieldKeys",
 		"_measurements",
+		"_name",
 		"_series",
+		"_tagKey",
 		"_tagKeys",
 		"_tags":
 		return true


### PR DESCRIPTION
This PR updates `IsSystemName()` for `_name` and `_tagKey`. When reviewing this, also consider that the intent is to make a followup [change here](https://github.com/influxdata/influxdb/blob/master/tsdb/store.go#L1503) to call this function instead of removing all expressions where the LHS begins with `_`. This change is to address [influxdb/#9522](https://github.com/influxdata/influxdb/issues/9522).