### PR TITLE
Add a bound parameter to the AST node

### DIFF
--- a/ast.go
+++ b/ast.go
@@ -256,6 +256,7 @@ func (*ShowUsersStatement) node()                  {}
 
 func (*BinaryExpr) node()      {}
 func (*BooleanLiteral) node()  {}
+func (*BoundParameter) node()  {}
 func (*Call) node()            {}
 func (*Dimension) node()       {}
 func (Dimensions) node()       {}
@@ -391,6 +392,7 @@ type Expr interface {
 
 func (*BinaryExpr) expr()      {}
 func (*BooleanLiteral) expr()  {}
+func (*BoundParameter) expr()  {}
 func (*Call) expr()            {}
 func (*Distinct) expr()        {}
 func (*DurationLiteral) expr() {}
@@ -415,6 +417,7 @@ type Literal interface {
 }
 
 func (*BooleanLiteral) literal()  {}
+func (*BoundParameter) literal()  {}
 func (*DurationLiteral) literal() {}
 func (*IntegerLiteral) literal()  {}
 func (*UnsignedLiteral) literal() {}
@@ -3646,6 +3649,18 @@ type NilLiteral struct{}
 
 // String returns a string representation of the literal.
 func (l *NilLiteral) String() string { return `nil` }
+
+// BoundParameter represents a bound parameter literal.
+// This is not available to the query language itself, but can be used when
+// constructing a query string from an AST.
+type BoundParameter struct {
+	Name string
+}
+
+// String returns a string representation of the bound parameter.
+func (bp *BoundParameter) String() string {
+	return fmt.Sprintf("$%s", QuoteIdent(bp.Name))
+}
 
 // BinaryExpr represents an operation between two expressions.
 type BinaryExpr struct {

--- a/ast_test.go
+++ b/ast_test.go
@@ -1672,6 +1672,40 @@ func TestShow_Privileges(t *testing.T) {
 	}
 }
 
+func TestBoundParameter_String(t *testing.T) {
+	stmt := &influxql.SelectStatement{
+		IsRawQuery: true,
+		Fields: []*influxql.Field{{
+			Expr: &influxql.VarRef{Val: "value"}}},
+		Sources: []influxql.Source{&influxql.Measurement{Name: "cpu"}},
+		Condition: &influxql.BinaryExpr{
+			Op:  influxql.GT,
+			LHS: &influxql.VarRef{Val: "value"},
+			RHS: &influxql.BoundParameter{Name: "value"},
+		},
+	}
+
+	if got, exp := stmt.String(), `SELECT value FROM cpu WHERE value > $value`; got != exp {
+		t.Fatalf("stmt mismatch:\n\nexp=%#v\n\ngot=%#v\n\n", exp, got)
+	}
+
+	stmt = &influxql.SelectStatement{
+		IsRawQuery: true,
+		Fields: []*influxql.Field{{
+			Expr: &influxql.VarRef{Val: "value"}}},
+		Sources: []influxql.Source{&influxql.Measurement{Name: "cpu"}},
+		Condition: &influxql.BinaryExpr{
+			Op:  influxql.GT,
+			LHS: &influxql.VarRef{Val: "value"},
+			RHS: &influxql.BoundParameter{Name: "multi-word value"},
+		},
+	}
+
+	if got, exp := stmt.String(), `SELECT value FROM cpu WHERE value > $"multi-word value"`; got != exp {
+		t.Fatalf("stmt mismatch:\n\nexp=%#v\n\ngot=%#v\n\n", exp, got)
+	}
+}
+
 // This test checks to ensure that we have given thought to the database
 // context required for security checks.  If a new statement is added, this
 // test will fail until it is categorized into the correct bucket below.

--- a/parser_test.go
+++ b/parser_test.go
@@ -1182,6 +1182,25 @@ func TestParser_ParseStatement(t *testing.T) {
 			},
 		},
 
+		// SELECT statement with a bound parameter that contains spaces
+		{
+			s: `SELECT value FROM cpu WHERE value > $"multi-word value"`,
+			params: map[string]interface{}{
+				"multi-word value": int64(2),
+			},
+			stmt: &influxql.SelectStatement{
+				IsRawQuery: true,
+				Fields: []*influxql.Field{{
+					Expr: &influxql.VarRef{Val: "value"}}},
+				Sources: []influxql.Source{&influxql.Measurement{Name: "cpu"}},
+				Condition: &influxql.BinaryExpr{
+					Op:  influxql.GT,
+					LHS: &influxql.VarRef{Val: "value"},
+					RHS: &influxql.IntegerLiteral{Val: 2},
+				},
+			},
+		},
+
 		// SELECT statement with a subquery
 		{
 			s: `SELECT sum(derivative) FROM (SELECT derivative(value) FROM cpu GROUP BY host) WHERE time >= now() - 1d GROUP BY time(1h)`,


### PR DESCRIPTION
This expression is not actually used by the parser and the parser won't
ever generate it, but this is helpful for utilities that need to
manipulate queries so they can insert bound parameters into the query
string and emit the query string.