### PR TITLE
feat: add CleanGroupByIntervalCache API

### DIFF
--- a/ast.go
+++ b/ast.go
@@ -1859,6 +1859,11 @@ func (s *SelectStatement) HasDimensionWildcard() bool {
 	return false
 }
 
+// CleanGroupByIntervalCache cleans the cached time interval.
+func (s *SelectStatement) CleanGroupByIntervalCache() {
+	s.groupByInterval = 0
+}
+
 // GroupByInterval extracts the time interval, if specified.
 func (s *SelectStatement) GroupByInterval() (time.Duration, error) {
 	// return if we've already pulled it out


### PR DESCRIPTION
After called GroupByInterval function, if we update the `time` in
Dimensions, we still got the cached interval.