### PR TITLE
refactor: Use strings.Builder

### DIFF
--- a/ast.go
+++ b/ast.go
@@ -444,7 +444,7 @@ type Sources []Source
 
 // String returns a string representation of a Sources array.
 func (a Sources) String() string {
-	var buf bytes.Buffer
+	var buf strings.Builder
 
 	ubound := len(a) - 1
 	for i, src := range a {
@@ -548,7 +548,7 @@ type SortField struct {
 
 // String returns a string representation of a sort field.
 func (field *SortField) String() string {
-	var buf bytes.Buffer
+	var buf strings.Builder
 	if field.Name != "" {
 		_, _ = buf.WriteString(field.Name)
 		_, _ = buf.WriteString(" ")
@@ -596,7 +596,7 @@ type CreateDatabaseStatement struct {
 
 // String returns a string representation of the create database statement.
 func (s *CreateDatabaseStatement) String() string {
-	var buf bytes.Buffer
+	var buf strings.Builder
 	_, _ = buf.WriteString("CREATE DATABASE ")
 	_, _ = buf.WriteString(QuoteIdent(s.Name))
 	if s.RetentionPolicyCreate {
@@ -635,7 +635,7 @@ type DropDatabaseStatement struct {
 
 // String returns a string representation of the drop database statement.
 func (s *DropDatabaseStatement) String() string {
-	var buf bytes.Buffer
+	var buf strings.Builder
 	_, _ = buf.WriteString("DROP DATABASE ")
 	_, _ = buf.WriteString(QuoteIdent(s.Name))
 	return buf.String()
@@ -657,7 +657,7 @@ type DropRetentionPolicyStatement struct {
 
 // String returns a string representation of the drop retention policy statement.
 func (s *DropRetentionPolicyStatement) String() string {
-	var buf bytes.Buffer
+	var buf strings.Builder
 	_, _ = buf.WriteString("DROP RETENTION POLICY ")
 	_, _ = buf.WriteString(QuoteIdent(s.Name))
 	_, _ = buf.WriteString(" ON ")
@@ -689,7 +689,7 @@ type CreateUserStatement struct {
 
 // String returns a string representation of the create user statement.
 func (s *CreateUserStatement) String() string {
-	var buf bytes.Buffer
+	var buf strings.Builder
 	_, _ = buf.WriteString("CREATE USER ")
 	_, _ = buf.WriteString(QuoteIdent(s.Name))
 	_, _ = buf.WriteString(" WITH PASSWORD ")
@@ -713,7 +713,7 @@ type DropUserStatement struct {
 
 // String returns a string representation of the drop user statement.
 func (s *DropUserStatement) String() string {
-	var buf bytes.Buffer
+	var buf strings.Builder
 	_, _ = buf.WriteString("DROP USER ")
 	_, _ = buf.WriteString(QuoteIdent(s.Name))
 	return buf.String()
@@ -770,7 +770,7 @@ type GrantStatement struct {
 
 // String returns a string representation of the grant statement.
 func (s *GrantStatement) String() string {
-	var buf bytes.Buffer
+	var buf strings.Builder
 	_, _ = buf.WriteString("GRANT ")
 	_, _ = buf.WriteString(s.Privilege.String())
 	_, _ = buf.WriteString(" ON ")
@@ -798,7 +798,7 @@ type GrantAdminStatement struct {
 
 // String returns a string representation of the grant admin statement.
 func (s *GrantAdminStatement) String() string {
-	var buf bytes.Buffer
+	var buf strings.Builder
 	_, _ = buf.WriteString("GRANT ALL PRIVILEGES TO ")
 	_, _ = buf.WriteString(QuoteIdent(s.User))
 	return buf.String()
@@ -820,7 +820,7 @@ type KillQueryStatement struct {
 
 // String returns a string representation of the kill query statement.
 func (s *KillQueryStatement) String() string {
-	var buf bytes.Buffer
+	var buf strings.Builder
 	_, _ = buf.WriteString("KILL QUERY ")
 	_, _ = buf.WriteString(strconv.FormatUint(s.QueryID, 10))
 	if s.Host != "" {
@@ -846,7 +846,7 @@ type SetPasswordUserStatement struct {
 
 // String returns a string representation of the set password statement.
 func (s *SetPasswordUserStatement) String() string {
-	var buf bytes.Buffer
+	var buf strings.Builder
 	_, _ = buf.WriteString("SET PASSWORD FOR ")
 	_, _ = buf.WriteString(QuoteIdent(s.Name))
 	_, _ = buf.WriteString(" = ")
@@ -873,7 +873,7 @@ type RevokeStatement struct {
 
 // String returns a string representation of the revoke statement.
 func (s *RevokeStatement) String() string {
-	var buf bytes.Buffer
+	var buf strings.Builder
 	_, _ = buf.WriteString("REVOKE ")
 	_, _ = buf.WriteString(s.Privilege.String())
 	_, _ = buf.WriteString(" ON ")
@@ -901,7 +901,7 @@ type RevokeAdminStatement struct {
 
 // String returns a string representation of the revoke admin statement.
 func (s *RevokeAdminStatement) String() string {
-	var buf bytes.Buffer
+	var buf strings.Builder
 	_, _ = buf.WriteString("REVOKE ALL PRIVILEGES FROM ")
 	_, _ = buf.WriteString(QuoteIdent(s.User))
 	return buf.String()
@@ -935,7 +935,7 @@ type CreateRetentionPolicyStatement struct {
 
 // String returns a string representation of the create retention policy.
 func (s *CreateRetentionPolicyStatement) String() string {
-	var buf bytes.Buffer
+	var buf strings.Builder
 	_, _ = buf.WriteString("CREATE RETENTION POLICY ")
 	_, _ = buf.WriteString(QuoteIdent(s.Name))
 	_, _ = buf.WriteString(" ON ")
@@ -987,7 +987,7 @@ type AlterRetentionPolicyStatement struct {
 
 // String returns a string representation of the alter retention policy statement.
 func (s *AlterRetentionPolicyStatement) String() string {
-	var buf bytes.Buffer
+	var buf strings.Builder
 	_, _ = buf.WriteString("ALTER RETENTION POLICY ")
 	_, _ = buf.WriteString(QuoteIdent(s.Name))
 	_, _ = buf.WriteString(" ON ")
@@ -1757,7 +1757,7 @@ func (s *SelectStatement) Reduce(valuer Valuer) *SelectStatement {
 
 // String returns a string representation of the select statement.
 func (s *SelectStatement) String() string {
-	var buf bytes.Buffer
+	var buf strings.Builder
 	_, _ = buf.WriteString("SELECT ")
 	_, _ = buf.WriteString(s.Fields.String())
 
@@ -2078,7 +2078,7 @@ func (t *Target) String() string {
 		return ""
 	}
 
-	var buf bytes.Buffer
+	var buf strings.Builder
 	_, _ = buf.WriteString("INTO ")
 	_, _ = buf.WriteString(t.Measurement.String())
 	if t.Measurement.Name == "" {
@@ -2097,7 +2097,7 @@ type ExplainStatement struct {
 
 // String returns a string representation of the explain statement.
 func (e *ExplainStatement) String() string {
-	var buf bytes.Buffer
+	var buf strings.Builder
 	buf.WriteString("EXPLAIN ")
 	if e.Analyze {
 		buf.WriteString("ANALYZE ")
@@ -2122,7 +2122,7 @@ type DeleteStatement struct {
 
 // String returns a string representation of the delete statement.
 func (s *DeleteStatement) String() string {
-	var buf bytes.Buffer
+	var buf strings.Builder
 	_, _ = buf.WriteString("DELETE FROM ")
 	_, _ = buf.WriteString(s.Source.String())
 	if s.Condition != nil {
@@ -2170,7 +2170,7 @@ type ShowSeriesStatement struct {
 
 // String returns a string representation of the list series statement.
 func (s *ShowSeriesStatement) String() string {
-	var buf bytes.Buffer
+	var buf strings.Builder
 	_, _ = buf.WriteString("SHOW SERIES")
 
 	if s.Database != "" {
@@ -2222,7 +2222,7 @@ type DropSeriesStatement struct {
 
 // String returns a string representation of the drop series statement.
 func (s *DropSeriesStatement) String() string {
-	var buf bytes.Buffer
+	var buf strings.Builder
 	buf.WriteString("DROP SERIES")
 
 	if s.Sources != nil {
@@ -2253,7 +2253,7 @@ type DeleteSeriesStatement struct {
 
 // String returns a string representation of the delete series statement.
 func (s *DeleteSeriesStatement) String() string {
-	var buf bytes.Buffer
+	var buf strings.Builder
 	buf.WriteString("DELETE")
 
 	if s.Sources != nil {
@@ -2282,7 +2282,7 @@ type DropShardStatement struct {
 
 // String returns a string representation of the drop series statement.
 func (s *DropShardStatement) String() string {
-	var buf bytes.Buffer
+	var buf strings.Builder
 	buf.WriteString("DROP SHARD ")
 	buf.WriteString(strconv.FormatUint(s.ID, 10))
 	return buf.String()
@@ -2317,7 +2317,7 @@ type ShowSeriesCardinalityStatement struct {
 
 // String returns a string representation of the show continuous queries statement.
 func (s *ShowSeriesCardinalityStatement) String() string {
-	var buf bytes.Buffer
+	var buf strings.Builder
 	_, _ = buf.WriteString("SHOW SERIES")
 
 	if s.Exact {
@@ -2384,7 +2384,7 @@ type ShowGrantsForUserStatement struct {
 
 // String returns a string representation of the show grants for user.
 func (s *ShowGrantsForUserStatement) String() string {
-	var buf bytes.Buffer
+	var buf strings.Builder
 	_, _ = buf.WriteString("SHOW GRANTS FOR ")
 	_, _ = buf.WriteString(QuoteIdent(s.Name))
 
@@ -2430,7 +2430,7 @@ type CreateContinuousQueryStatement struct {
 
 // String returns a string representation of the statement.
 func (s *CreateContinuousQueryStatement) String() string {
-	var buf bytes.Buffer
+	var buf strings.Builder
 	fmt.Fprintf(&buf, "CREATE CONTINUOUS QUERY %s ON %s ", QuoteIdent(s.Name), QuoteIdent(s.Database))
 
 	if s.ResampleEvery > 0 || s.ResampleFor > 0 {
@@ -2522,7 +2522,7 @@ type ShowMeasurementCardinalityStatement struct {
 
 // String returns a string representation of the statement.
 func (s *ShowMeasurementCardinalityStatement) String() string {
-	var buf bytes.Buffer
+	var buf strings.Builder
 	_, _ = buf.WriteString("SHOW MEASUREMENT")
 
 	if s.Exact {
@@ -2594,7 +2594,7 @@ type ShowMeasurementsStatement struct {
 
 // String returns a string representation of the statement.
 func (s *ShowMeasurementsStatement) String() string {
-	var buf bytes.Buffer
+	var buf strings.Builder
 	_, _ = buf.WriteString("SHOW MEASUREMENTS")
 
 	if s.Database != "" {
@@ -2647,7 +2647,7 @@ type DropMeasurementStatement struct {
 
 // String returns a string representation of the drop measurement statement.
 func (s *DropMeasurementStatement) String() string {
-	var buf bytes.Buffer
+	var buf strings.Builder
 	_, _ = buf.WriteString("DROP MEASUREMENT ")
 	_, _ = buf.WriteString(QuoteIdent(s.Name))
 	return buf.String()
@@ -2679,7 +2679,7 @@ type ShowRetentionPoliciesStatement struct {
 
 // String returns a string representation of a ShowRetentionPoliciesStatement.
 func (s *ShowRetentionPoliciesStatement) String() string {
-	var buf bytes.Buffer
+	var buf strings.Builder
 	_, _ = buf.WriteString("SHOW RETENTION POLICIES")
 	if s.Database != "" {
 		_, _ = buf.WriteString(" ON ")
@@ -2705,7 +2705,7 @@ type ShowStatsStatement struct {
 
 // String returns a string representation of a ShowStatsStatement.
 func (s *ShowStatsStatement) String() string {
-	var buf bytes.Buffer
+	var buf strings.Builder
 	_, _ = buf.WriteString("SHOW STATS")
 	if s.Module != "" {
 		_, _ = buf.WriteString(" FOR ")
@@ -2749,7 +2749,7 @@ type ShowDiagnosticsStatement struct {
 
 // String returns a string representation of the ShowDiagnosticsStatement.
 func (s *ShowDiagnosticsStatement) String() string {
-	var buf bytes.Buffer
+	var buf strings.Builder
 	_, _ = buf.WriteString("SHOW DIAGNOSTICS")
 	if s.Module != "" {
 		_, _ = buf.WriteString(" FOR ")
@@ -2774,7 +2774,7 @@ type CreateSubscriptionStatement struct {
 
 // String returns a string representation of the CreateSubscriptionStatement.
 func (s *CreateSubscriptionStatement) String() string {
-	var buf bytes.Buffer
+	var buf strings.Builder
 	_, _ = buf.WriteString("CREATE SUBSCRIPTION ")
 	_, _ = buf.WriteString(QuoteIdent(s.Name))
 	_, _ = buf.WriteString(" ON ")
@@ -2870,7 +2870,7 @@ type ShowTagKeysStatement struct {
 
 // String returns a string representation of the statement.
 func (s *ShowTagKeysStatement) String() string {
-	var buf bytes.Buffer
+	var buf strings.Builder
 	_, _ = buf.WriteString("SHOW TAG KEYS")
 
 	if s.Database != "" {
@@ -2930,7 +2930,7 @@ type ShowTagKeyCardinalityStatement struct {
 
 // String returns a string representation of the statement.
 func (s *ShowTagKeyCardinalityStatement) String() string {
-	var buf bytes.Buffer
+	var buf strings.Builder
 	_, _ = buf.WriteString("SHOW TAG KEY ")
 	if s.Exact {
 		_, _ = buf.WriteString("EXACT ")
@@ -3004,7 +3004,7 @@ type ShowTagValuesStatement struct {
 
 // String returns a string representation of the statement.
 func (s *ShowTagValuesStatement) String() string {
-	var buf bytes.Buffer
+	var buf strings.Builder
 	_, _ = buf.WriteString("SHOW TAG VALUES")
 
 	if s.Database != "" {
@@ -3066,7 +3066,7 @@ type ShowTagValuesCardinalityStatement struct {
 
 // String returns a string representation of the statement.
 func (s *ShowTagValuesCardinalityStatement) String() string {
-	var buf bytes.Buffer
+	var buf strings.Builder
 	_, _ = buf.WriteString("SHOW TAG VALUES ")
 	if s.Exact {
 		_, _ = buf.WriteString("EXACT ")
@@ -3142,7 +3142,7 @@ type ShowFieldKeyCardinalityStatement struct {
 
 // String returns a string representation of the statement.
 func (s *ShowFieldKeyCardinalityStatement) String() string {
-	var buf bytes.Buffer
+	var buf strings.Builder
 	_, _ = buf.WriteString("SHOW FIELD KEY ")
 
 	if s.Exact {
@@ -3208,7 +3208,7 @@ type ShowFieldKeysStatement struct {
 
 // String returns a string representation of the statement.
 func (s *ShowFieldKeysStatement) String() string {
-	var buf bytes.Buffer
+	var buf strings.Builder
 	_, _ = buf.WriteString("SHOW FIELD KEYS")
 
 	if s.Database != "" {
@@ -3416,7 +3416,7 @@ func (m *Measurement) Clone() *Measurement {
 
 // String returns a string representation of the measurement.
 func (m *Measurement) String() string {
-	var buf bytes.Buffer
+	var buf strings.Builder
 	if m.Database != "" {
 		_, _ = buf.WriteString(QuoteIdent(m.Database))
 		_, _ = buf.WriteString(".")
@@ -3593,7 +3593,7 @@ type ListLiteral struct {
 
 // String returns a string representation of the literal.
 func (s *ListLiteral) String() string {
-	var buf bytes.Buffer
+	var buf strings.Builder
 	_, _ = buf.WriteString("(")
 	for idx, tagKey := range s.Vals {
 		if idx != 0 {

--- a/parser.go
+++ b/parser.go
@@ -1,7 +1,6 @@
 package influxql
 
 import (
-	"bytes"
 	"errors"
 	"fmt"
 	"io"
@@ -3089,7 +3088,7 @@ func QuoteString(s string) string {
 
 // QuoteIdent returns a quoted identifier from multiple bare identifiers.
 func QuoteIdent(segments ...string) string {
-	var buf bytes.Buffer
+	var buf strings.Builder
 	for i, segment := range segments {
 		needQuote := IdentNeedsQuotes(segment) ||
 			((i < len(segments)-1) && segment != "") || // not last segment && not ""

--- a/sanitize.go
+++ b/sanitize.go
@@ -1,8 +1,8 @@
 package influxql
 
 import (
-	"bytes"
 	"regexp"
+	"strings"
 )
 
 var (
@@ -21,7 +21,7 @@ var (
 // as much as possible.
 func Sanitize(query string) string {
 	if matches := sanitizeSetPassword.FindAllStringSubmatchIndex(query, -1); matches != nil {
-		var buf bytes.Buffer
+		var buf strings.Builder
 		i := 0
 		for _, match := range matches {
 			buf.WriteString(query[i:match[2]])
@@ -33,7 +33,7 @@ func Sanitize(query string) string {
 	}
 
 	if matches := sanitizeCreatePassword.FindAllStringSubmatchIndex(query, -1); matches != nil {
-		var buf bytes.Buffer
+		var buf strings.Builder
 		i := 0
 		for _, match := range matches {
 			buf.WriteString(query[i:match[2]])

--- a/scanner.go
+++ b/scanner.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"strings"
 )
 
 // Scanner represents a lexical scanner for InfluxQL.
@@ -139,7 +140,7 @@ func (s *Scanner) Scan() (tok Token, pos Pos, lit string) {
 // scanWhitespace consumes the current rune and all contiguous whitespace.
 func (s *Scanner) scanWhitespace() (tok Token, pos Pos, lit string) {
 	// Create a buffer and read the current character into it.
-	var buf bytes.Buffer
+	var buf strings.Builder
 	ch, pos := s.r.curr()
 	_, _ = buf.WriteRune(ch)
 
@@ -195,7 +196,7 @@ func (s *Scanner) scanIdent(lookup bool) (tok Token, pos Pos, lit string) {
 	_, pos = s.r.read()
 	s.r.unread()
 
-	var buf bytes.Buffer
+	var buf strings.Builder
 	for {
 		if ch, _ := s.r.read(); ch == eof {
 			break
@@ -263,7 +264,7 @@ func (s *Scanner) ScanRegex() (tok Token, pos Pos, lit string) {
 
 // scanNumber consumes anything that looks like the start of a number.
 func (s *Scanner) scanNumber() (tok Token, pos Pos, lit string) {
-	var buf bytes.Buffer
+	var buf strings.Builder
 
 	// Check if the initial rune is a ".".
 	ch, pos := s.r.curr()
@@ -333,7 +334,7 @@ func (s *Scanner) scanNumber() (tok Token, pos Pos, lit string) {
 
 // scanDigits consumes a contiguous series of digits.
 func (s *Scanner) scanDigits() string {
-	var buf bytes.Buffer
+	var buf strings.Builder
 	for {
 		ch, _ := s.r.read()
 		if !isDigit(ch) {
@@ -561,7 +562,7 @@ func ScanString(r io.RuneScanner) (string, error) {
 		return "", errBadString
 	}
 
-	var buf bytes.Buffer
+	var buf strings.Builder
 	for {
 		ch0, _, err := r.ReadRune()
 		if ch0 == ending {
@@ -596,7 +597,7 @@ var errBadEscape = errors.New("bad escape")
 func ScanBareIdent(r io.RuneScanner) string {
 	// Read every ident character into the buffer.
 	// Non-ident characters and EOF will cause the loop to exit.
-	var buf bytes.Buffer
+	var buf strings.Builder
 	for {
 		ch, _, err := r.ReadRune()
 		if err != nil {


### PR DESCRIPTION
When used for appending strings, strings.Builder yields fewer
allocations and is generally faster than bytes.Buffer.

```
benchmark                           old ns/op     new ns/op     delta
BenchmarkQuery_String-4             3219          2899          -9.94%
BenchmarkExprNames-4                6655          6646          -0.14%
BenchmarkEval-4                     519           522           +0.58%
BenchmarkParserParseStatement-4     6768          6083          -10.12%
BenchmarkSanitize-4                 5846          5525          -5.49%

benchmark                           old MB/s     new MB/s     speedup
BenchmarkParserParseStatement-4     6.65         7.40         1.11x

benchmark                           old allocs     new allocs     delta
BenchmarkQuery_String-4             44             39             -11.36%
BenchmarkExprNames-4                10             10             +0.00%
BenchmarkEval-4                     6              6              +0.00%
BenchmarkParserParseStatement-4     56             44             -21.43%
BenchmarkSanitize-4                 10             7              -30.00%

benchmark                           old bytes     new bytes     delta
BenchmarkQuery_String-4             1336          736           -44.91%
BenchmarkExprNames-4                240           240           +0.00%
BenchmarkEval-4                     80            80            +0.00%
BenchmarkParserParseStatement-4     6448          5320          -17.49%
BenchmarkSanitize-4                 1204          769           -36.13%
```