### PR TITLE
feat: support db and rp wildcards in show measurements statement

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,19 @@
+version: 2.1
+
+jobs:
+  test:
+    docker:
+      - image: circleci/golang:1.16
+    steps:
+      - checkout
+      - run:
+          name: Run tests
+          command: |
+            go vet ./...
+            go test ./...
+
+workflows:
+  version: 2.1
+  on_push:
+    jobs:
+      test

--- a/README.md
+++ b/README.md
@@ -626,7 +626,7 @@ SHOW GRANTS FOR "jdoe"
 ### SHOW MEASUREMENTS
 
 ```
-show_measurements_stmt = "SHOW MEASUREMENTS" [ with_measurement_clause ] [ where_clause ] [ limit_clause ] [ offset_clause ] .
+show_measurements_stmt = "SHOW MEASUREMENTS" [on_clause] [ with_measurement_clause ] [ where_clause ] [ limit_clause ] [ offset_clause ] .
 ```
 
 #### Examples:
@@ -634,6 +634,12 @@ show_measurements_stmt = "SHOW MEASUREMENTS" [ with_measurement_clause ] [ where
 ```sql
 -- show all measurements
 SHOW MEASUREMENTS
+
+-- show all measurements on all databases
+SHOW MEASUREMENTS ON *.*
+
+-- show all measurements on specific database and retention policy
+SHOW MEASUREMENTS ON mydb.myrp
 
 -- show measurements where region tag = 'uswest' AND host tag = 'serverA'
 SHOW MEASUREMENTS WHERE "region" = 'uswest' AND "host" = 'serverA'

--- a/ast.go
+++ b/ast.go
@@ -2575,6 +2575,12 @@ type ShowMeasurementsStatement struct {
 	// Database to query. If blank, use the default database.
 	Database string
 
+	// Retention policy to query. If blank, use all retention policies (do not use default)
+	RetentionPolicy string
+
+	WildcardDatabase bool
+	WildcardRetentionPolicy bool
+
 	// Measurement name or regex.
 	Source Source
 
@@ -2597,9 +2603,19 @@ func (s *ShowMeasurementsStatement) String() string {
 	var buf strings.Builder
 	_, _ = buf.WriteString("SHOW MEASUREMENTS")
 
-	if s.Database != "" {
+	if s.Database != "" || s.WildcardDatabase {
 		_, _ = buf.WriteString(" ON ")
-		_, _ = buf.WriteString(s.Database)
+		if s.WildcardDatabase {
+			_, _ = buf.WriteString("*")
+		} else {
+			_, _ = buf.WriteString(s.Database)
+		}
+		if s.WildcardRetentionPolicy {
+			_, _ = buf.WriteString(".*")
+		} else if s.RetentionPolicy != "" {
+			_, _ = buf.WriteString(".")
+			_, _ = buf.WriteString(s.RetentionPolicy)
+		}
 	}
 	if s.Source != nil {
 		_, _ = buf.WriteString(" WITH MEASUREMENT ")

--- a/parser.go
+++ b/parser.go
@@ -1064,9 +1064,26 @@ func (p *Parser) parseShowMeasurementsStatement() (*ShowMeasurementsStatement, e
 	// Parse optional ON clause.
 	if tok, _, _ := p.ScanIgnoreWhitespace(); tok == ON {
 		// Parse the database.
-		stmt.Database, err = p.ParseIdent()
-		if err != nil {
-			return nil, err
+		tok, pos, lit := p.ScanIgnoreWhitespace()
+		if tok == IDENT {
+			stmt.Database = lit
+		} else if tok == MUL {
+			stmt.WildcardDatabase = true
+		} else{
+			return nil, newParseError(tokstr(tok, lit), []string{"identifier or *"}, pos)
+		}
+
+		if tok, _, _ := p.ScanIgnoreWhitespace(); tok == DOT {
+			tok, pos, lit := p.ScanIgnoreWhitespace()
+			if tok == IDENT {
+				stmt.RetentionPolicy = lit
+			} else if tok == MUL {
+				stmt.WildcardRetentionPolicy = true
+			} else{
+				return nil, newParseError(tokstr(tok, lit), []string{"identifier or *"}, pos)
+			}
+		} else {
+			p.Unscan()
 		}
 	} else {
 		p.Unscan()

--- a/parser_test.go
+++ b/parser_test.go
@@ -1953,6 +1953,50 @@ func TestParser_ParseStatement(t *testing.T) {
 			},
 		},
 
+		// SHOW MEASUREMENTS ON db0.rp0
+		{
+			s: `SHOW MEASUREMENTS ON db0.rp0`,
+			stmt: &influxql.ShowMeasurementsStatement{
+				Database: "db0",
+				RetentionPolicy: "rp0",
+			},
+		},
+
+		// SHOW MEASUREMENTS ON *
+		{
+			s: `SHOW MEASUREMENTS ON *`,
+			stmt: &influxql.ShowMeasurementsStatement{
+				WildcardDatabase: true,
+			},
+		},
+
+		// SHOW MEASUREMENTS ON *.*
+		{
+			s: `SHOW MEASUREMENTS ON *.*`,
+			stmt: &influxql.ShowMeasurementsStatement{
+				WildcardDatabase: true,
+				WildcardRetentionPolicy: true,
+			},
+		},
+
+		// SHOW MEASUREMENTS ON db0.*
+		{
+			s: `SHOW MEASUREMENTS ON db0.*`,
+			stmt: &influxql.ShowMeasurementsStatement{
+				Database: "db0",
+				WildcardRetentionPolicy: true,
+			},
+		},
+
+		// SHOW MEASUREMENTS ON *.rp0
+		{
+			s: `SHOW MEASUREMENTS ON *.rp0`,
+			stmt: &influxql.ShowMeasurementsStatement{
+				RetentionPolicy: "rp0",
+				WildcardDatabase: true,
+			},
+		},
+
 		// SHOW MEASUREMENTS WITH MEASUREMENT = cpu
 		{
 			s: `SHOW MEASUREMENTS WITH MEASUREMENT = cpu`,


### PR DESCRIPTION
To support https://github.com/influxdata/influxdb/issues/3318, we need to be able to represent wildcards and retention policies when parsing the show measurements statement.