### PR TITLE
chore: update to go 1.18

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 jobs:
   test:
     docker:
-      - image: circleci/golang:1.16
+      - image: circleci/golang:1.18
     steps:
       - checkout
       - run:

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/influxdata/influxql
 
-go 1.13
+go 1.18
 
 require google.golang.org/protobuf v1.27.1

--- a/parser.go
+++ b/parser.go
@@ -1069,7 +1069,7 @@ func (p *Parser) parseShowMeasurementsStatement() (*ShowMeasurementsStatement, e
 			stmt.Database = lit
 		} else if tok == MUL {
 			stmt.WildcardDatabase = true
-		} else{
+		} else {
 			return nil, newParseError(tokstr(tok, lit), []string{"identifier or *"}, pos)
 		}
 
@@ -1079,7 +1079,7 @@ func (p *Parser) parseShowMeasurementsStatement() (*ShowMeasurementsStatement, e
 				stmt.RetentionPolicy = lit
 			} else if tok == MUL {
 				stmt.WildcardRetentionPolicy = true
-			} else{
+			} else {
 				return nil, newParseError(tokstr(tok, lit), []string{"identifier or *"}, pos)
 			}
 		} else {

--- a/parser_test.go
+++ b/parser_test.go
@@ -1957,7 +1957,7 @@ func TestParser_ParseStatement(t *testing.T) {
 		{
 			s: `SHOW MEASUREMENTS ON db0.rp0`,
 			stmt: &influxql.ShowMeasurementsStatement{
-				Database: "db0",
+				Database:        "db0",
 				RetentionPolicy: "rp0",
 			},
 		},
@@ -1974,7 +1974,7 @@ func TestParser_ParseStatement(t *testing.T) {
 		{
 			s: `SHOW MEASUREMENTS ON *.*`,
 			stmt: &influxql.ShowMeasurementsStatement{
-				WildcardDatabase: true,
+				WildcardDatabase:        true,
 				WildcardRetentionPolicy: true,
 			},
 		},
@@ -1983,7 +1983,7 @@ func TestParser_ParseStatement(t *testing.T) {
 		{
 			s: `SHOW MEASUREMENTS ON db0.*`,
 			stmt: &influxql.ShowMeasurementsStatement{
-				Database: "db0",
+				Database:                "db0",
 				WildcardRetentionPolicy: true,
 			},
 		},
@@ -1992,7 +1992,7 @@ func TestParser_ParseStatement(t *testing.T) {
 		{
 			s: `SHOW MEASUREMENTS ON *.rp0`,
 			stmt: &influxql.ShowMeasurementsStatement{
-				RetentionPolicy: "rp0",
+				RetentionPolicy:  "rp0",
 				WildcardDatabase: true,
 			},
 		},


### PR DESCRIPTION
* chore: update to go 1.18
* chore: go fmt with 1.18

This was prompted by a fix in go 1.18.7 (and 1.19.2) to `regex/syntax`, which `influxql` imports. By updating the go version we ensure that people will use `influxql` with a new enough version that has the bug fix.

Note, `influxql` is imported by quite a few projects, so choose 1.18 instead of 1.19 since not all of those projects are updated to 1.19 yet (though, `influxql` tests pass with either 1.18 or 1.19).