### PR TITLE
chore(circleci): use modern cimg/go:1.18

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 jobs:
   test:
     docker:
-      - image: circleci/golang:1.18
+      - image: cimg/go:1.18
     steps:
       - checkout
       - run:


### PR DESCRIPTION
The recent push to master [failed](https://app.circleci.com/pipelines/github/influxdata/influxql/10/workflows/9a4166d3-8ba0-441d-b27a-8c3e8e259d5e/jobs/10) due to `circleci/golang:1.18` not existing. Indeed, `circleci/golang` are for the old, deprecated convenience images. Use `cimg/go:1.18` instead.