### PR TITLE
feat: Add `VERBOSE` option to `EXPLAIN`

### DIFF
--- a/ast.go
+++ b/ast.go
@@ -2093,6 +2093,7 @@ type ExplainStatement struct {
 	Statement *SelectStatement
 
 	Analyze bool
+	Verbose bool
 }
 
 // String returns a string representation of the explain statement.
@@ -2101,6 +2102,9 @@ func (e *ExplainStatement) String() string {
 	buf.WriteString("EXPLAIN ")
 	if e.Analyze {
 		buf.WriteString("ANALYZE ")
+	}
+	if e.Verbose {
+		buf.WriteString("VERBOSE ")
 	}
 	buf.WriteString(e.Statement.String())
 	return buf.String()

--- a/parser.go
+++ b/parser.go
@@ -1961,6 +1961,12 @@ func (p *Parser) parseExplainStatement() (*ExplainStatement, error) {
 		p.Unscan()
 	}
 
+	if tok, _, _ := p.ScanIgnoreWhitespace(); tok == VERBOSE {
+		stmt.Verbose = true
+	} else {
+		p.Unscan()
+	}
+
 	if tok, pos, lit := p.ScanIgnoreWhitespace(); tok != SELECT {
 		return nil, newParseError(tokstr(tok, lit), []string{"SELECT"}, pos)
 	}

--- a/parser_test.go
+++ b/parser_test.go
@@ -1744,6 +1744,21 @@ func TestParser_ParseStatement(t *testing.T) {
 			},
 		},
 
+		// EXPLAIN VERBOSE ...
+		{
+			s: `EXPLAIN VERBOSE SELECT * FROM cpu`,
+			stmt: &influxql.ExplainStatement{
+				Statement: &influxql.SelectStatement{
+					IsRawQuery: true,
+					Fields: []*influxql.Field{
+						{Expr: &influxql.Wildcard{}},
+					},
+					Sources: []influxql.Source{&influxql.Measurement{Name: "cpu"}},
+				},
+				Verbose: true,
+			},
+		},
+
 		// EXPLAIN ANALYZE ...
 		{
 			s: `EXPLAIN ANALYZE SELECT * FROM cpu`,
@@ -1755,6 +1770,21 @@ func TestParser_ParseStatement(t *testing.T) {
 					},
 					Sources: []influxql.Source{&influxql.Measurement{Name: "cpu"}},
 				},
+				Analyze: true,
+			},
+		},
+		// EXPLAIN ANALYZE VERBOSE ...
+		{
+			s: `EXPLAIN ANALYZE VERBOSE SELECT * FROM cpu`,
+			stmt: &influxql.ExplainStatement{
+				Statement: &influxql.SelectStatement{
+					IsRawQuery: true,
+					Fields: []*influxql.Field{
+						{Expr: &influxql.Wildcard{}},
+					},
+					Sources: []influxql.Source{&influxql.Measurement{Name: "cpu"}},
+				},
+				Verbose: true,
 				Analyze: true,
 			},
 		},

--- a/token.go
+++ b/token.go
@@ -138,6 +138,7 @@ const (
 	USER
 	USERS
 	VALUES
+	VERBOSE
 	WHERE
 	WITH
 	WRITE
@@ -261,6 +262,7 @@ var tokens = [...]string{
 	USER:          "USER",
 	USERS:         "USERS",
 	VALUES:        "VALUES",
+	VERBOSE:       "VERBOSE",
 	WHERE:         "WHERE",
 	WITH:          "WITH",
 	WRITE:         "WRITE",


### PR DESCRIPTION
This PR extends the `EXPLAIN` and `EXPLAIN ANALYZE` statement to support the `VERBOSE` keyword.