### PR TITLE
Handle empty measurements

### DIFF
--- a/ast.go
+++ b/ast.go
@@ -3475,7 +3475,11 @@ func (m *Measurement) String() string {
 		_, _ = buf.WriteString(m.Regex.String())
 	}
 
-	return buf.String()
+	if buf.Len() == 0 {
+		return QuoteIdent("")
+	} else {
+		return buf.String()
+	}
 }
 
 // SubQuery is a source with a SelectStatement as the backing store.


### PR DESCRIPTION
Queries like
```
SHOW FIELD KEYS FROM ""
```
parses properly but don't get serialized properly as the empty measurements gets serialized into an empty string (without the quotes).

This PR fixes this by properly handling empty Measurements and serialize it as `""`.