### PR TITLE
feat: add FUTURE LIMIT and PAST LIMIT to retention policies

### DIFF
--- a/ast.go
+++ b/ast.go
@@ -617,10 +617,6 @@ func (s *CreateDatabaseStatement) String() string {
 			_, _ = buf.WriteString(" SHARD DURATION ")
 			_, _ = buf.WriteString(s.RetentionPolicyShardGroupDuration.String())
 		}
-		if s.RetentionPolicyName != "" {
-			_, _ = buf.WriteString(" NAME ")
-			_, _ = buf.WriteString(QuoteIdent(s.RetentionPolicyName))
-		}
 		if s.FutureWriteLimit != nil {
 			_, _ = buf.WriteString(" FUTURE LIMIT ")
 			_, _ = buf.WriteString(FormatDuration(*s.FutureWriteLimit))
@@ -628,6 +624,10 @@ func (s *CreateDatabaseStatement) String() string {
 		if s.PastWriteLimit != nil {
 			_, _ = buf.WriteString(" PAST LIMIT ")
 			_, _ = buf.WriteString(FormatDuration(*s.PastWriteLimit))
+		}
+		if s.RetentionPolicyName != "" {
+			_, _ = buf.WriteString(" NAME ")
+			_, _ = buf.WriteString(QuoteIdent(s.RetentionPolicyName))
 		}
 	}
 

--- a/ast.go
+++ b/ast.go
@@ -931,6 +931,12 @@ type CreateRetentionPolicyStatement struct {
 
 	// Shard Duration.
 	ShardGroupDuration time.Duration
+
+	// Error on writes after this duration from now
+	FutureWriteLimit time.Duration
+
+	// Error on writes before this duration from now
+	PastWriteLimit time.Duration
 }
 
 // String returns a string representation of the create retention policy.
@@ -983,6 +989,12 @@ type AlterRetentionPolicyStatement struct {
 
 	// Duration of the Shard.
 	ShardGroupDuration *time.Duration
+
+	// Cutoff for future writes
+	FutureWriteLimit *time.Duration
+
+	// Cutoff for past writes
+	PastWriteLimit *time.Duration
 }
 
 // String returns a string representation of the alter retention policy statement.

--- a/ast.go
+++ b/ast.go
@@ -957,6 +957,14 @@ func (s *CreateRetentionPolicyStatement) String() string {
 	if s.Default {
 		_, _ = buf.WriteString(" DEFAULT")
 	}
+	if s.FutureWriteLimit != 0 {
+		_, _ = buf.WriteString(" FUTURE LIMIT ")
+		_, _ = buf.WriteString(FormatDuration(s.FutureWriteLimit))
+	}
+	if s.PastWriteLimit != 0 {
+		_, _ = buf.WriteString(" PAST LIMIT ")
+		_, _ = buf.WriteString(FormatDuration(s.PastWriteLimit))
+	}
 	return buf.String()
 }
 

--- a/ast.go
+++ b/ast.go
@@ -617,11 +617,11 @@ func (s *CreateDatabaseStatement) String() string {
 			_, _ = buf.WriteString(" SHARD DURATION ")
 			_, _ = buf.WriteString(s.RetentionPolicyShardGroupDuration.String())
 		}
-		if s.FutureWriteLimit != nil {
+		if s.FutureWriteLimit != nil && *s.FutureWriteLimit > 0 {
 			_, _ = buf.WriteString(" FUTURE LIMIT ")
 			_, _ = buf.WriteString(FormatDuration(*s.FutureWriteLimit))
 		}
-		if s.PastWriteLimit != nil {
+		if s.PastWriteLimit != nil && *s.PastWriteLimit > 0 {
 			_, _ = buf.WriteString(" PAST LIMIT ")
 			_, _ = buf.WriteString(FormatDuration(*s.PastWriteLimit))
 		}

--- a/ast.go
+++ b/ast.go
@@ -592,6 +592,10 @@ type CreateDatabaseStatement struct {
 
 	// RetentionPolicyShardGroupDuration indicates shard group duration for the new database.
 	RetentionPolicyShardGroupDuration time.Duration
+
+	FutureWriteLimit *time.Duration
+
+	PastWriteLimit *time.Duration
 }
 
 // String returns a string representation of the create database statement.
@@ -616,6 +620,14 @@ func (s *CreateDatabaseStatement) String() string {
 		if s.RetentionPolicyName != "" {
 			_, _ = buf.WriteString(" NAME ")
 			_, _ = buf.WriteString(QuoteIdent(s.RetentionPolicyName))
+		}
+		if s.FutureWriteLimit != nil {
+			_, _ = buf.WriteString(" FUTURE LIMIT ")
+			_, _ = buf.WriteString(FormatDuration(*s.FutureWriteLimit))
+		}
+		if s.PastWriteLimit != nil {
+			_, _ = buf.WriteString(" PAST LIMIT ")
+			_, _ = buf.WriteString(FormatDuration(*s.PastWriteLimit))
 		}
 	}
 
@@ -1030,6 +1042,16 @@ func (s *AlterRetentionPolicyStatement) String() string {
 
 	if s.Default {
 		_, _ = buf.WriteString(" DEFAULT")
+	}
+
+	if s.FutureWriteLimit != nil && *s.FutureWriteLimit != 0 {
+		_, _ = buf.WriteString(" FUTURE LIMIT ")
+		_, _ = buf.WriteString(FormatDuration(*s.FutureWriteLimit))
+	}
+
+	if s.PastWriteLimit != nil && *s.PastWriteLimit != 0 {
+		_, _ = buf.WriteString(" PAST LIMIT ")
+		_, _ = buf.WriteString(FormatDuration(*s.PastWriteLimit))
 	}
 
 	return buf.String()

--- a/parser.go
+++ b/parser.go
@@ -284,6 +284,8 @@ func (p *Parser) parseCreateRetentionPolicyStatement() (*CreateRetentionPolicySt
 			return nil, err
 		}
 		stmt.FutureWriteLimit = d
+	} else {
+		p.Unscan()
 	}
 	if tok, _, _ := p.ScanIgnoreWhitespace(); tok == PAST {
 		d, err := p.parseWriteLimit()
@@ -291,6 +293,8 @@ func (p *Parser) parseCreateRetentionPolicyStatement() (*CreateRetentionPolicySt
 			return nil, err
 		}
 		stmt.PastWriteLimit = d
+	} else {
+		p.Unscan()
 	}
 	return stmt, nil
 }

--- a/parser.go
+++ b/parser.go
@@ -1845,6 +1845,8 @@ func (p *Parser) parseCreateDatabaseStatement() (*CreateDatabaseStatement, error
 			}
 		}
 
+		// TODO(DSB): add parsing for FutureWriteLimit ad PastWriteLimit
+
 		// Look for "NAME"
 		if err := p.parseTokens([]Token{NAME}); err != nil {
 			p.Unscan()

--- a/parser_test.go
+++ b/parser_test.go
@@ -3150,6 +3150,68 @@ func TestParser_ParseStatement(t *testing.T) {
 			},
 		},
 
+		{
+			s: `CREATE DATABASE testdb WITH DURATION 24h PAST LIMIT 32s`,
+			stmt: &influxql.CreateDatabaseStatement{
+				Name:                    "testdb",
+				RetentionPolicyCreate:   true,
+				RetentionPolicyDuration: duration(24 * time.Hour),
+				PastWriteLimit:          duration(32 * time.Second),
+			},
+		},
+		{
+			s: `CREATE DATABASE testdb WITH SHARD DURATION 30m FUTURE LIMIT 45m`,
+			stmt: &influxql.CreateDatabaseStatement{
+				Name:                              "testdb",
+				RetentionPolicyCreate:             true,
+				RetentionPolicyShardGroupDuration: 30 * time.Minute,
+				FutureWriteLimit:                  duration(45 * time.Minute),
+			},
+		},
+		{
+			s: `CREATE DATABASE testdb WITH REPLICATION 2 FUTURE LIMIT 1h PAST LIMIT 67ms`,
+			stmt: &influxql.CreateDatabaseStatement{
+				Name:                       "testdb",
+				RetentionPolicyCreate:      true,
+				RetentionPolicyReplication: intptr(2),
+				FutureWriteLimit:           duration(time.Hour),
+				PastWriteLimit:             duration(67 * time.Millisecond),
+			},
+		},
+		{
+			s: `CREATE DATABASE testdb WITH FUTURE LIMIT 13h PAST LIMIT 1h NAME test_name`,
+			stmt: &influxql.CreateDatabaseStatement{
+				Name:                  "testdb",
+				RetentionPolicyCreate: true,
+				RetentionPolicyName:   "test_name",
+				FutureWriteLimit:      duration(13 * time.Hour),
+				PastWriteLimit:        duration(time.Hour),
+			},
+		},
+		{
+			s: `CREATE DATABASE testdb WITH DURATION 24h REPLICATION 2 PAST LIMIT 59h NAME test_name`,
+			stmt: &influxql.CreateDatabaseStatement{
+				Name:                       "testdb",
+				RetentionPolicyCreate:      true,
+				RetentionPolicyDuration:    duration(24 * time.Hour),
+				RetentionPolicyReplication: intptr(2),
+				RetentionPolicyName:        "test_name",
+				PastWriteLimit:             duration(59 * time.Hour),
+			},
+		},
+		{
+			s: `CREATE DATABASE testdb WITH DURATION 24h REPLICATION 2 SHARD DURATION 10m FUTURE LIMIT 6704ns NAME test_name`,
+			stmt: &influxql.CreateDatabaseStatement{
+				Name:                              "testdb",
+				RetentionPolicyCreate:             true,
+				RetentionPolicyDuration:           duration(24 * time.Hour),
+				RetentionPolicyReplication:        intptr(2),
+				RetentionPolicyName:               "test_name",
+				RetentionPolicyShardGroupDuration: 10 * time.Minute,
+				FutureWriteLimit:                  duration(6704 * time.Nanosecond),
+			},
+		},
+
 		// CREATE USER statement
 		{
 			s: `CREATE USER testuser WITH PASSWORD 'pwd1337'`,
@@ -3628,7 +3690,7 @@ func TestParser_ParseStatement(t *testing.T) {
 		{s: `DROP FOO`, err: `found FOO, expected CONTINUOUS, DATABASE, MEASUREMENT, RETENTION, SERIES, SHARD, SUBSCRIPTION, USER at line 1, char 6`},
 		{s: `CREATE FOO`, err: `found FOO, expected CONTINUOUS, DATABASE, USER, RETENTION, SUBSCRIPTION at line 1, char 8`},
 		{s: `CREATE DATABASE`, err: `found EOF, expected identifier at line 1, char 17`},
-		{s: `CREATE DATABASE "testdb" WITH`, err: `found EOF, expected DURATION, NAME, REPLICATION, SHARD at line 1, char 31`},
+		{s: `CREATE DATABASE "testdb" WITH`, err: `found EOF, expected DURATION, NAME, REPLICATION, SHARD, FUTURE, PAST at line 1, char 31`},
 		{s: `CREATE DATABASE "testdb" WITH DURATION`, err: `found EOF, expected duration at line 1, char 40`},
 		{s: `CREATE DATABASE "testdb" WITH REPLICATION`, err: `found EOF, expected integer at line 1, char 43`},
 		{s: `CREATE DATABASE "testdb" WITH NAME`, err: `found EOF, expected identifier at line 1, char 36`},

--- a/parser_test.go
+++ b/parser_test.go
@@ -3389,6 +3389,40 @@ func TestParser_ParseStatement(t *testing.T) {
 				ShardGroupDuration: time.Second,
 			},
 		},
+		{
+			s: `CREATE RETENTION POLICY policy1 ON testdb DURATION 1h REPLICATION 2 SHARD DURATION 1s PAST LIMIT 1h`,
+			stmt: &influxql.CreateRetentionPolicyStatement{
+				Name:               "policy1",
+				Database:           "testdb",
+				Duration:           time.Hour,
+				Replication:        2,
+				ShardGroupDuration: time.Second,
+				PastWriteLimit:     time.Hour,
+			},
+		},
+		{
+			s: `CREATE RETENTION POLICY policy1 ON testdb DURATION 1h REPLICATION 2 SHARD DURATION 1s FUTURE LIMIT 35m`,
+			stmt: &influxql.CreateRetentionPolicyStatement{
+				Name:               "policy1",
+				Database:           "testdb",
+				Duration:           time.Hour,
+				Replication:        2,
+				ShardGroupDuration: time.Second,
+				FutureWriteLimit:   time.Minute * 35,
+			},
+		},
+		{
+			s: `CREATE RETENTION POLICY policy1 ON testdb DURATION 1h REPLICATION 2 SHARD DURATION 1s FUTURE LIMIT 12h PAST LIMIT 3s`,
+			stmt: &influxql.CreateRetentionPolicyStatement{
+				Name:               "policy1",
+				Database:           "testdb",
+				Duration:           time.Hour,
+				Replication:        2,
+				ShardGroupDuration: time.Second,
+				FutureWriteLimit:   time.Hour * 12,
+				PastWriteLimit:     time.Second * 3,
+			},
+		},
 
 		// ALTER RETENTION POLICY
 		{

--- a/parser_test.go
+++ b/parser_test.go
@@ -3692,7 +3692,7 @@ func TestParser_ParseStatement(t *testing.T) {
 		{s: `ALTER RETENTION`, err: `found EOF, expected POLICY at line 1, char 17`},
 		{s: `ALTER RETENTION POLICY`, err: `found EOF, expected identifier at line 1, char 24`},
 		{s: `ALTER RETENTION POLICY policy1`, err: `found EOF, expected ON at line 1, char 32`}, {s: `ALTER RETENTION POLICY policy1 ON`, err: `found EOF, expected identifier at line 1, char 35`},
-		{s: `ALTER RETENTION POLICY policy1 ON testdb`, err: `found EOF, expected DURATION, REPLICATION, SHARD, DEFAULT at line 1, char 42`},
+		{s: `ALTER RETENTION POLICY policy1 ON testdb`, err: `found EOF, expected DURATION, REPLICATION, SHARD, DEFAULT, FUTURE, PAST at line 1, char 42`},
 		{s: `ALTER RETENTION POLICY policy1 ON testdb REPLICATION 1 REPLICATION 2`, err: `found duplicate REPLICATION option at line 1, char 56`},
 		{s: `ALTER RETENTION POLICY policy1 ON testdb DURATION 15251w`, err: `overflowed duration 15251w: choose a smaller duration or INF at line 1, char 51`},
 		{s: `ALTER RETENTION POLICY policy1 ON testdb DURATION INF SHARD DURATION INF`, err: `invalid duration INF for shard duration at line 1, char 70`},

--- a/token.go
+++ b/token.go
@@ -93,6 +93,7 @@ const (
 	FIELD
 	FOR
 	FROM
+	FUTURE
 	GRANT
 	GRANTS
 	GROUP
@@ -112,6 +113,7 @@ const (
 	ON
 	ORDER
 	PASSWORD
+	PAST
 	POLICY
 	POLICIES
 	PRIVILEGES
@@ -217,6 +219,7 @@ var tokens = [...]string{
 	FIELD:         "FIELD",
 	FOR:           "FOR",
 	FROM:          "FROM",
+	FUTURE:        "FUTURE",
 	GRANT:         "GRANT",
 	GRANTS:        "GRANTS",
 	GROUP:         "GROUP",
@@ -236,6 +239,7 @@ var tokens = [...]string{
 	ON:            "ON",
 	ORDER:         "ORDER",
 	PASSWORD:      "PASSWORD",
+	PAST:          "PAST",
 	POLICY:        "POLICY",
 	POLICIES:      "POLICIES",
 	PRIVILEGES:    "PRIVILEGES",


### PR DESCRIPTION
Add optional write limits in the future and past to retention policies.
This will allow InfluxDB to reject writes that are within a retention
period, but outside of the write limits.  Customers desire this to stop
rogue users from writing data far in the past or future, causing 
performance and data quality issues. 

Syntax is `FUTURE LIMIT <duration> PAST LIMIT <duration>`
for 
`CREATE DATABASE WITH`
`CREATE RETENTION POLICY `
`ALTER RETENTION POLICY`

helps: https://github.com/influxdata/influxdb/issues/25424