### PR TITLE
feat: Adds `date_part` function tests

### DIFF
--- a/ast_test.go
+++ b/ast_test.go
@@ -1021,6 +1021,107 @@ func TestParseString(t *testing.T) {
 	}
 }
 
+// Ensure that the String() value of a statement is parseable
+func TestDatePartFunctionParse(t *testing.T) {
+	var tests = []struct {
+		stmt string
+	}{
+		// Basic date_part with dow (day of week)
+		{
+			stmt: `SELECT "cpu load" FROM myseries WHERE date_part(time, DOW) > 0`,
+		},
+		// date_part with year
+		{
+			stmt: `SELECT value FROM myseries WHERE date_part(time, YEAR) = 2024`,
+		},
+		// date_part with quarter
+		{
+			stmt: `SELECT value FROM myseries WHERE date_part(time, QUARTER) BETWEEN 1 AND 4`,
+		},
+		// date_part with month
+		{
+			stmt: `SELECT value FROM myseries WHERE date_part(time, MONTH) = 12`,
+		},
+		// date_part with week
+		{
+			stmt: `SELECT value FROM myseries WHERE date_part(time, WEEK) < 52`,
+		},
+		// date_part with day
+		{
+			stmt: `SELECT value FROM myseries WHERE date_part(time, DAY) > 15`,
+		},
+		// date_part with hour
+		{
+			stmt: `SELECT value FROM myseries WHERE date_part(time, HOUR) BETWEEN 9 AND 17`,
+		},
+		// date_part with minute
+		{
+			stmt: `SELECT value FROM myseries WHERE date_part(time, MINUTE) = 30`,
+		},
+		// date_part with second
+		{
+			stmt: `SELECT value FROM myseries WHERE date_part(time, SECOND) < 60`,
+		},
+		// date_part with millisecond
+		{
+			stmt: `SELECT value FROM myseries WHERE date_part(time, MILLISECOND) > 0`,
+		},
+		// date_part with microsecond
+		{
+			stmt: `SELECT value FROM myseries WHERE date_part(time, MICROSECOND) > 0`,
+		},
+		// date_part with nanosecond
+		{
+			stmt: `SELECT value FROM myseries WHERE date_part(time, NANOSECOND) > 0`,
+		},
+		// date_part with doy (day of year)
+		{
+			stmt: `SELECT value FROM myseries WHERE date_part(time, DOY) <= 365`,
+		},
+		// date_part with epoch (seconds since Unix epoch)
+		{
+			stmt: `SELECT value FROM myseries WHERE date_part(time, EPOCH) > 1609459200`,
+		},
+		// date_part with isodow (ISO day of week, Monday = 0)
+		{
+			stmt: `SELECT value FROM myseries WHERE date_part(time, ISODOW) != 5`,
+		},
+		// date_part in SELECT clause
+		{
+			stmt: `SELECT date_part(time, HOUR) FROM myseries`,
+		},
+		// Multiple date_part functions
+		{
+			stmt: `SELECT value FROM myseries WHERE date_part(time, DOW) != 0 AND date_part(time, DOW) != 6`,
+		},
+		// date_part with now() function
+		{
+			stmt: `SELECT value FROM myseries WHERE date_part(now(), HOUR) > 12`,
+		},
+		// date_part in complex WHERE clause (weekday filter from example)
+		{
+			stmt: `SELECT * FROM some_measurement WHERE time >= now() - 10d AND time <= now() AND (date_part(time, DOW) != 0 AND date_part(time, DOW) != 6)`,
+		},
+	}
+
+	for _, tt := range tests {
+		// Parse statement.
+		stmt, err := influxql.NewParser(strings.NewReader(tt.stmt)).ParseStatement()
+		if err != nil {
+			t.Fatalf("invalid statement: %q: %s", tt.stmt, err)
+		}
+
+		stmtCopy, err := influxql.NewParser(strings.NewReader(stmt.String())).ParseStatement()
+		if err != nil {
+			t.Fatalf("failed to parse string: %v\norig: %v\ngot: %v", err, tt.stmt, stmt.String())
+		}
+
+		if !reflect.DeepEqual(stmt, stmtCopy) {
+			t.Fatalf("statement changed after stringifying and re-parsing:\noriginal : %v\nre-parsed: %v\n", tt.stmt, stmtCopy.String())
+		}
+	}
+}
+
 // Ensure an expression can be reduced.
 func TestEval(t *testing.T) {
 	for i, tt := range []struct {

--- a/ast_test.go
+++ b/ast_test.go
@@ -1028,79 +1028,79 @@ func TestDatePartFunctionParse(t *testing.T) {
 	}{
 		// Basic date_part with dow (day of week)
 		{
-			stmt: `SELECT "cpu load" FROM myseries WHERE date_part(time, DOW) > 0`,
+			stmt: `SELECT "cpu load" FROM myseries WHERE date_part('dow', time) > 0`,
 		},
 		// date_part with year
 		{
-			stmt: `SELECT value FROM myseries WHERE date_part(time, YEAR) = 2024`,
+			stmt: `SELECT value FROM myseries WHERE date_part('year', time) = 2024`,
 		},
 		// date_part with quarter
 		{
-			stmt: `SELECT value FROM myseries WHERE date_part(time, QUARTER) BETWEEN 1 AND 4`,
+			stmt: `SELECT value FROM myseries WHERE date_part('quarter', time) BETWEEN 1 AND 4`,
 		},
 		// date_part with month
 		{
-			stmt: `SELECT value FROM myseries WHERE date_part(time, MONTH) = 12`,
+			stmt: `SELECT value FROM myseries WHERE date_part('month', time) = 12`,
 		},
 		// date_part with week
 		{
-			stmt: `SELECT value FROM myseries WHERE date_part(time, WEEK) < 52`,
+			stmt: `SELECT value FROM myseries WHERE date_part('week', time) < 52`,
 		},
 		// date_part with day
 		{
-			stmt: `SELECT value FROM myseries WHERE date_part(time, DAY) > 15`,
+			stmt: `SELECT value FROM myseries WHERE date_part('day', time) > 15`,
 		},
 		// date_part with hour
 		{
-			stmt: `SELECT value FROM myseries WHERE date_part(time, HOUR) BETWEEN 9 AND 17`,
+			stmt: `SELECT value FROM myseries WHERE date_part('hour', time) BETWEEN 9 AND 17`,
 		},
 		// date_part with minute
 		{
-			stmt: `SELECT value FROM myseries WHERE date_part(time, MINUTE) = 30`,
+			stmt: `SELECT value FROM myseries WHERE date_part('minute', time) = 30`,
 		},
 		// date_part with second
 		{
-			stmt: `SELECT value FROM myseries WHERE date_part(time, SECOND) < 60`,
+			stmt: `SELECT value FROM myseries WHERE date_part('second', time) < 60`,
 		},
 		// date_part with millisecond
 		{
-			stmt: `SELECT value FROM myseries WHERE date_part(time, MILLISECOND) > 0`,
+			stmt: `SELECT value FROM myseries WHERE date_part('millisecond', time) > 0`,
 		},
 		// date_part with microsecond
 		{
-			stmt: `SELECT value FROM myseries WHERE date_part(time, MICROSECOND) > 0`,
+			stmt: `SELECT value FROM myseries WHERE date_part('microsecond', time) > 0`,
 		},
 		// date_part with nanosecond
 		{
-			stmt: `SELECT value FROM myseries WHERE date_part(time, NANOSECOND) > 0`,
+			stmt: `SELECT value FROM myseries WHERE date_part('nanosecond', time) > 0`,
 		},
 		// date_part with doy (day of year)
 		{
-			stmt: `SELECT value FROM myseries WHERE date_part(time, DOY) <= 365`,
+			stmt: `SELECT value FROM myseries WHERE date_part('doy', time) <= 365`,
 		},
 		// date_part with epoch (seconds since Unix epoch)
 		{
-			stmt: `SELECT value FROM myseries WHERE date_part(time, EPOCH) > 1609459200`,
+			stmt: `SELECT value FROM myseries WHERE date_part('epoch', time) > 1609459200`,
 		},
 		// date_part with isodow (ISO day of week, Monday = 0)
 		{
-			stmt: `SELECT value FROM myseries WHERE date_part(time, ISODOW) != 5`,
+			stmt: `SELECT value FROM myseries WHERE date_part('isodow', time) != 5`,
 		},
 		// date_part in SELECT clause
 		{
-			stmt: `SELECT date_part(time, HOUR) FROM myseries`,
+			stmt: `SELECT date_part('hour', time) FROM myseries`,
 		},
 		// Multiple date_part functions
 		{
-			stmt: `SELECT value FROM myseries WHERE date_part(time, DOW) != 0 AND date_part(time, DOW) != 6`,
+			stmt: `SELECT value FROM myseries WHERE date_part('dow', time) != 0 AND date_part('dow', time) != 6`,
 		},
 		// date_part with now() function
 		{
-			stmt: `SELECT value FROM myseries WHERE date_part(now(), HOUR) > 12`,
+			stmt: `SELECT value FROM myseries WHERE date_part('hour', now()) > 12`,
 		},
 		// date_part in complex WHERE clause (weekday filter from example)
 		{
-			stmt: `SELECT * FROM some_measurement WHERE time >= now() - 10d AND time <= now() AND (date_part(time, DOW) != 0 AND date_part(time, DOW) != 6)`,
+			stmt: `SELECT * FROM some_measurement WHERE time >= now() - 10d AND time <= now() AND (date_part('dow', time) != 0 AND date_part('dow', time) != 6)`,
 		},
 	}
 

--- a/parser_test.go
+++ b/parser_test.go
@@ -630,6 +630,406 @@ func TestParser_ParseStatement(t *testing.T) {
 			},
 		},
 
+		// date_part with dow (day of week)
+		{
+			s: `SELECT my_field FROM myseries WHERE date_part(time, DOW) = 1`,
+			stmt: &influxql.SelectStatement{
+				IsRawQuery: true,
+				Sources:    []influxql.Source{&influxql.Measurement{Name: "myseries"}},
+				Fields: []*influxql.Field{
+					{Expr: &influxql.VarRef{Val: "my_field"}},
+				},
+				Condition: &influxql.BinaryExpr{
+					Op: influxql.EQ,
+					LHS: &influxql.Call{
+						Name: "date_part",
+						Args: []influxql.Expr{
+							&influxql.VarRef{Val: "time"},
+							&influxql.VarRef{Val: "DOW"},
+						},
+					},
+					RHS: &influxql.IntegerLiteral{Val: 1},
+				},
+			},
+		},
+
+		// date_part with year
+		{
+			s: `SELECT value FROM myseries WHERE date_part(time, YEAR) = 2024`,
+			stmt: &influxql.SelectStatement{
+				IsRawQuery: true,
+				Sources:    []influxql.Source{&influxql.Measurement{Name: "myseries"}},
+				Fields: []*influxql.Field{
+					{Expr: &influxql.VarRef{Val: "value"}},
+				},
+				Condition: &influxql.BinaryExpr{
+					Op: influxql.EQ,
+					LHS: &influxql.Call{
+						Name: "date_part",
+						Args: []influxql.Expr{
+							&influxql.VarRef{Val: "time"},
+							&influxql.VarRef{Val: "YEAR"},
+						},
+					},
+					RHS: &influxql.IntegerLiteral{Val: 2024},
+				},
+			},
+		},
+
+		// date_part with quarter
+		{
+			s: `SELECT value FROM myseries WHERE date_part(time, QUARTER) = 2`,
+			stmt: &influxql.SelectStatement{
+				IsRawQuery: true,
+				Sources:    []influxql.Source{&influxql.Measurement{Name: "myseries"}},
+				Fields: []*influxql.Field{
+					{Expr: &influxql.VarRef{Val: "value"}},
+				},
+				Condition: &influxql.BinaryExpr{
+					Op: influxql.EQ,
+					LHS: &influxql.Call{
+						Name: "date_part",
+						Args: []influxql.Expr{
+							&influxql.VarRef{Val: "time"},
+							&influxql.VarRef{Val: "QUARTER"},
+						},
+					},
+					RHS: &influxql.IntegerLiteral{Val: 2},
+				},
+			},
+		},
+
+		// date_part with month
+		{
+			s: `SELECT value FROM myseries WHERE date_part(time, MONTH) = 12`,
+			stmt: &influxql.SelectStatement{
+				IsRawQuery: true,
+				Sources:    []influxql.Source{&influxql.Measurement{Name: "myseries"}},
+				Fields: []*influxql.Field{
+					{Expr: &influxql.VarRef{Val: "value"}},
+				},
+				Condition: &influxql.BinaryExpr{
+					Op: influxql.EQ,
+					LHS: &influxql.Call{
+						Name: "date_part",
+						Args: []influxql.Expr{
+							&influxql.VarRef{Val: "time"},
+							&influxql.VarRef{Val: "MONTH"},
+						},
+					},
+					RHS: &influxql.IntegerLiteral{Val: 12},
+				},
+			},
+		},
+
+		// date_part with week
+		{
+			s: `SELECT value FROM myseries WHERE date_part(time, WEEK) < 52`,
+			stmt: &influxql.SelectStatement{
+				IsRawQuery: true,
+				Sources:    []influxql.Source{&influxql.Measurement{Name: "myseries"}},
+				Fields: []*influxql.Field{
+					{Expr: &influxql.VarRef{Val: "value"}},
+				},
+				Condition: &influxql.BinaryExpr{
+					Op: influxql.LT,
+					LHS: &influxql.Call{
+						Name: "date_part",
+						Args: []influxql.Expr{
+							&influxql.VarRef{Val: "time"},
+							&influxql.VarRef{Val: "WEEK"},
+						},
+					},
+					RHS: &influxql.IntegerLiteral{Val: 52},
+				},
+			},
+		},
+
+		// date_part with day
+		{
+			s: `SELECT value FROM myseries WHERE date_part(time, DAY) > 15`,
+			stmt: &influxql.SelectStatement{
+				IsRawQuery: true,
+				Sources:    []influxql.Source{&influxql.Measurement{Name: "myseries"}},
+				Fields: []*influxql.Field{
+					{Expr: &influxql.VarRef{Val: "value"}},
+				},
+				Condition: &influxql.BinaryExpr{
+					Op: influxql.GT,
+					LHS: &influxql.Call{
+						Name: "date_part",
+						Args: []influxql.Expr{
+							&influxql.VarRef{Val: "time"},
+							&influxql.VarRef{Val: "DAY"},
+						},
+					},
+					RHS: &influxql.IntegerLiteral{Val: 15},
+				},
+			},
+		},
+
+		// date_part with hour
+		{
+			s: `SELECT value FROM myseries WHERE date_part(time, HOUR) = 14`,
+			stmt: &influxql.SelectStatement{
+				IsRawQuery: true,
+				Sources:    []influxql.Source{&influxql.Measurement{Name: "myseries"}},
+				Fields: []*influxql.Field{
+					{Expr: &influxql.VarRef{Val: "value"}},
+				},
+				Condition: &influxql.BinaryExpr{
+					Op: influxql.EQ,
+					LHS: &influxql.Call{
+						Name: "date_part",
+						Args: []influxql.Expr{
+							&influxql.VarRef{Val: "time"},
+							&influxql.VarRef{Val: "HOUR"},
+						},
+					},
+					RHS: &influxql.IntegerLiteral{Val: 14},
+				},
+			},
+		},
+
+		// date_part with minute
+		{
+			s: `SELECT value FROM myseries WHERE date_part(time, MINUTE) = 30`,
+			stmt: &influxql.SelectStatement{
+				IsRawQuery: true,
+				Sources:    []influxql.Source{&influxql.Measurement{Name: "myseries"}},
+				Fields: []*influxql.Field{
+					{Expr: &influxql.VarRef{Val: "value"}},
+				},
+				Condition: &influxql.BinaryExpr{
+					Op: influxql.EQ,
+					LHS: &influxql.Call{
+						Name: "date_part",
+						Args: []influxql.Expr{
+							&influxql.VarRef{Val: "time"},
+							&influxql.VarRef{Val: "MINUTE"},
+						},
+					},
+					RHS: &influxql.IntegerLiteral{Val: 30},
+				},
+			},
+		},
+
+		// date_part with second
+		{
+			s: `SELECT value FROM myseries WHERE date_part(time, SECOND) < 60`,
+			stmt: &influxql.SelectStatement{
+				IsRawQuery: true,
+				Sources:    []influxql.Source{&influxql.Measurement{Name: "myseries"}},
+				Fields: []*influxql.Field{
+					{Expr: &influxql.VarRef{Val: "value"}},
+				},
+				Condition: &influxql.BinaryExpr{
+					Op: influxql.LT,
+					LHS: &influxql.Call{
+						Name: "date_part",
+						Args: []influxql.Expr{
+							&influxql.VarRef{Val: "time"},
+							&influxql.VarRef{Val: "SECOND"},
+						},
+					},
+					RHS: &influxql.IntegerLiteral{Val: 60},
+				},
+			},
+		},
+
+		// date_part with millisecond
+		{
+			s: `SELECT value FROM myseries WHERE date_part(time, MILLISECOND) > 0`,
+			stmt: &influxql.SelectStatement{
+				IsRawQuery: true,
+				Sources:    []influxql.Source{&influxql.Measurement{Name: "myseries"}},
+				Fields: []*influxql.Field{
+					{Expr: &influxql.VarRef{Val: "value"}},
+				},
+				Condition: &influxql.BinaryExpr{
+					Op: influxql.GT,
+					LHS: &influxql.Call{
+						Name: "date_part",
+						Args: []influxql.Expr{
+							&influxql.VarRef{Val: "time"},
+							&influxql.VarRef{Val: "MILLISECOND"},
+						},
+					},
+					RHS: &influxql.IntegerLiteral{Val: 0},
+				},
+			},
+		},
+
+		// date_part with microsecond
+		{
+			s: `SELECT value FROM myseries WHERE date_part(time, MICROSECOND) > 0`,
+			stmt: &influxql.SelectStatement{
+				IsRawQuery: true,
+				Sources:    []influxql.Source{&influxql.Measurement{Name: "myseries"}},
+				Fields: []*influxql.Field{
+					{Expr: &influxql.VarRef{Val: "value"}},
+				},
+				Condition: &influxql.BinaryExpr{
+					Op: influxql.GT,
+					LHS: &influxql.Call{
+						Name: "date_part",
+						Args: []influxql.Expr{
+							&influxql.VarRef{Val: "time"},
+							&influxql.VarRef{Val: "MICROSECOND"},
+						},
+					},
+					RHS: &influxql.IntegerLiteral{Val: 0},
+				},
+			},
+		},
+
+		// date_part with nanosecond
+		{
+			s: `SELECT value FROM myseries WHERE date_part(time, NANOSECOND) > 0`,
+			stmt: &influxql.SelectStatement{
+				IsRawQuery: true,
+				Sources:    []influxql.Source{&influxql.Measurement{Name: "myseries"}},
+				Fields: []*influxql.Field{
+					{Expr: &influxql.VarRef{Val: "value"}},
+				},
+				Condition: &influxql.BinaryExpr{
+					Op: influxql.GT,
+					LHS: &influxql.Call{
+						Name: "date_part",
+						Args: []influxql.Expr{
+							&influxql.VarRef{Val: "time"},
+							&influxql.VarRef{Val: "NANOSECOND"},
+						},
+					},
+					RHS: &influxql.IntegerLiteral{Val: 0},
+				},
+			},
+		},
+
+		// date_part with doy (day of year)
+		{
+			s: `SELECT value FROM myseries WHERE date_part(time, DOY) <= 365`,
+			stmt: &influxql.SelectStatement{
+				IsRawQuery: true,
+				Sources:    []influxql.Source{&influxql.Measurement{Name: "myseries"}},
+				Fields: []*influxql.Field{
+					{Expr: &influxql.VarRef{Val: "value"}},
+				},
+				Condition: &influxql.BinaryExpr{
+					Op: influxql.LTE,
+					LHS: &influxql.Call{
+						Name: "date_part",
+						Args: []influxql.Expr{
+							&influxql.VarRef{Val: "time"},
+							&influxql.VarRef{Val: "DOY"},
+						},
+					},
+					RHS: &influxql.IntegerLiteral{Val: 365},
+				},
+			},
+		},
+
+		// date_part with epoch (seconds since Unix epoch)
+		{
+			s: `SELECT value FROM myseries WHERE date_part(time, EPOCH) > 1609459200`,
+			stmt: &influxql.SelectStatement{
+				IsRawQuery: true,
+				Sources:    []influxql.Source{&influxql.Measurement{Name: "myseries"}},
+				Fields: []*influxql.Field{
+					{Expr: &influxql.VarRef{Val: "value"}},
+				},
+				Condition: &influxql.BinaryExpr{
+					Op: influxql.GT,
+					LHS: &influxql.Call{
+						Name: "date_part",
+						Args: []influxql.Expr{
+							&influxql.VarRef{Val: "time"},
+							&influxql.VarRef{Val: "EPOCH"},
+						},
+					},
+					RHS: &influxql.IntegerLiteral{Val: 1609459200},
+				},
+			},
+		},
+
+		// date_part with isodow (ISO day of week, Monday = 1)
+		{
+			s: `SELECT value FROM myseries WHERE date_part(time, ISODOW) != 5`,
+			stmt: &influxql.SelectStatement{
+				IsRawQuery: true,
+				Sources:    []influxql.Source{&influxql.Measurement{Name: "myseries"}},
+				Fields: []*influxql.Field{
+					{Expr: &influxql.VarRef{Val: "value"}},
+				},
+				Condition: &influxql.BinaryExpr{
+					Op: influxql.NEQ,
+					LHS: &influxql.Call{
+						Name: "date_part",
+						Args: []influxql.Expr{
+							&influxql.VarRef{Val: "time"},
+							&influxql.VarRef{Val: "ISODOW"},
+						},
+					},
+					RHS: &influxql.IntegerLiteral{Val: 5},
+				},
+			},
+		},
+
+		// date_part in SELECT clause
+		{
+			s: `SELECT date_part(time, HOUR) FROM myseries`,
+			stmt: &influxql.SelectStatement{
+				IsRawQuery: false,
+				Sources:    []influxql.Source{&influxql.Measurement{Name: "myseries"}},
+				Fields: []*influxql.Field{
+					{Expr: &influxql.Call{
+						Name: "date_part",
+						Args: []influxql.Expr{
+							&influxql.VarRef{Val: "time"},
+							&influxql.VarRef{Val: "HOUR"},
+						},
+					}},
+				},
+			},
+		},
+
+		// Multiple date_part functions (weekday filter example)
+		{
+			s: `SELECT value FROM myseries WHERE date_part(time, DOW) != 0 AND date_part(time, DOW) != 6`,
+			stmt: &influxql.SelectStatement{
+				IsRawQuery: true,
+				Sources:    []influxql.Source{&influxql.Measurement{Name: "myseries"}},
+				Fields: []*influxql.Field{
+					{Expr: &influxql.VarRef{Val: "value"}},
+				},
+				Condition: &influxql.BinaryExpr{
+					Op: influxql.AND,
+					LHS: &influxql.BinaryExpr{
+						Op: influxql.NEQ,
+						LHS: &influxql.Call{
+							Name: "date_part",
+							Args: []influxql.Expr{
+								&influxql.VarRef{Val: "time"},
+								&influxql.VarRef{Val: "DOW"},
+							},
+						},
+						RHS: &influxql.IntegerLiteral{Val: 0},
+					},
+					RHS: &influxql.BinaryExpr{
+						Op: influxql.NEQ,
+						LHS: &influxql.Call{
+							Name: "date_part",
+							Args: []influxql.Expr{
+								&influxql.VarRef{Val: "time"},
+								&influxql.VarRef{Val: "DOW"},
+							},
+						},
+						RHS: &influxql.IntegerLiteral{Val: 6},
+					},
+				},
+			},
+		},
+
 		// SELECT statement (lowercase)
 		{
 			s: `select my_field from myseries`,

--- a/parser_test.go
+++ b/parser_test.go
@@ -632,7 +632,7 @@ func TestParser_ParseStatement(t *testing.T) {
 
 		// date_part with dow (day of week)
 		{
-			s: `SELECT my_field FROM myseries WHERE date_part(time, DOW) = 1`,
+			s: `SELECT my_field FROM myseries WHERE date_part('dow', time) = 1`,
 			stmt: &influxql.SelectStatement{
 				IsRawQuery: true,
 				Sources:    []influxql.Source{&influxql.Measurement{Name: "myseries"}},
@@ -644,8 +644,8 @@ func TestParser_ParseStatement(t *testing.T) {
 					LHS: &influxql.Call{
 						Name: "date_part",
 						Args: []influxql.Expr{
+							&influxql.StringLiteral{Val: "dow"},
 							&influxql.VarRef{Val: "time"},
-							&influxql.VarRef{Val: "DOW"},
 						},
 					},
 					RHS: &influxql.IntegerLiteral{Val: 1},
@@ -655,7 +655,7 @@ func TestParser_ParseStatement(t *testing.T) {
 
 		// date_part with year
 		{
-			s: `SELECT value FROM myseries WHERE date_part(time, YEAR) = 2024`,
+			s: `SELECT value FROM myseries WHERE date_part('year', time) = 2024`,
 			stmt: &influxql.SelectStatement{
 				IsRawQuery: true,
 				Sources:    []influxql.Source{&influxql.Measurement{Name: "myseries"}},
@@ -667,8 +667,8 @@ func TestParser_ParseStatement(t *testing.T) {
 					LHS: &influxql.Call{
 						Name: "date_part",
 						Args: []influxql.Expr{
+							&influxql.StringLiteral{Val: "year"},
 							&influxql.VarRef{Val: "time"},
-							&influxql.VarRef{Val: "YEAR"},
 						},
 					},
 					RHS: &influxql.IntegerLiteral{Val: 2024},
@@ -678,7 +678,7 @@ func TestParser_ParseStatement(t *testing.T) {
 
 		// date_part with quarter
 		{
-			s: `SELECT value FROM myseries WHERE date_part(time, QUARTER) = 2`,
+			s: `SELECT value FROM myseries WHERE date_part('quarter', time) = 2`,
 			stmt: &influxql.SelectStatement{
 				IsRawQuery: true,
 				Sources:    []influxql.Source{&influxql.Measurement{Name: "myseries"}},
@@ -690,8 +690,8 @@ func TestParser_ParseStatement(t *testing.T) {
 					LHS: &influxql.Call{
 						Name: "date_part",
 						Args: []influxql.Expr{
+							&influxql.StringLiteral{Val: "quarter"},
 							&influxql.VarRef{Val: "time"},
-							&influxql.VarRef{Val: "QUARTER"},
 						},
 					},
 					RHS: &influxql.IntegerLiteral{Val: 2},
@@ -701,7 +701,7 @@ func TestParser_ParseStatement(t *testing.T) {
 
 		// date_part with month
 		{
-			s: `SELECT value FROM myseries WHERE date_part(time, MONTH) = 12`,
+			s: `SELECT value FROM myseries WHERE date_part('month', time) = 12`,
 			stmt: &influxql.SelectStatement{
 				IsRawQuery: true,
 				Sources:    []influxql.Source{&influxql.Measurement{Name: "myseries"}},
@@ -713,8 +713,8 @@ func TestParser_ParseStatement(t *testing.T) {
 					LHS: &influxql.Call{
 						Name: "date_part",
 						Args: []influxql.Expr{
+							&influxql.StringLiteral{Val: "month"},
 							&influxql.VarRef{Val: "time"},
-							&influxql.VarRef{Val: "MONTH"},
 						},
 					},
 					RHS: &influxql.IntegerLiteral{Val: 12},
@@ -724,7 +724,7 @@ func TestParser_ParseStatement(t *testing.T) {
 
 		// date_part with week
 		{
-			s: `SELECT value FROM myseries WHERE date_part(time, WEEK) < 52`,
+			s: `SELECT value FROM myseries WHERE date_part('week', time) < 52`,
 			stmt: &influxql.SelectStatement{
 				IsRawQuery: true,
 				Sources:    []influxql.Source{&influxql.Measurement{Name: "myseries"}},
@@ -736,8 +736,8 @@ func TestParser_ParseStatement(t *testing.T) {
 					LHS: &influxql.Call{
 						Name: "date_part",
 						Args: []influxql.Expr{
+							&influxql.StringLiteral{Val: "week"},
 							&influxql.VarRef{Val: "time"},
-							&influxql.VarRef{Val: "WEEK"},
 						},
 					},
 					RHS: &influxql.IntegerLiteral{Val: 52},
@@ -747,7 +747,7 @@ func TestParser_ParseStatement(t *testing.T) {
 
 		// date_part with day
 		{
-			s: `SELECT value FROM myseries WHERE date_part(time, DAY) > 15`,
+			s: `SELECT value FROM myseries WHERE date_part('day', time) > 15`,
 			stmt: &influxql.SelectStatement{
 				IsRawQuery: true,
 				Sources:    []influxql.Source{&influxql.Measurement{Name: "myseries"}},
@@ -759,8 +759,8 @@ func TestParser_ParseStatement(t *testing.T) {
 					LHS: &influxql.Call{
 						Name: "date_part",
 						Args: []influxql.Expr{
+							&influxql.StringLiteral{Val: "day"},
 							&influxql.VarRef{Val: "time"},
-							&influxql.VarRef{Val: "DAY"},
 						},
 					},
 					RHS: &influxql.IntegerLiteral{Val: 15},
@@ -770,7 +770,7 @@ func TestParser_ParseStatement(t *testing.T) {
 
 		// date_part with hour
 		{
-			s: `SELECT value FROM myseries WHERE date_part(time, HOUR) = 14`,
+			s: `SELECT value FROM myseries WHERE date_part('hour', time) = 14`,
 			stmt: &influxql.SelectStatement{
 				IsRawQuery: true,
 				Sources:    []influxql.Source{&influxql.Measurement{Name: "myseries"}},
@@ -782,8 +782,8 @@ func TestParser_ParseStatement(t *testing.T) {
 					LHS: &influxql.Call{
 						Name: "date_part",
 						Args: []influxql.Expr{
+							&influxql.StringLiteral{Val: "hour"},
 							&influxql.VarRef{Val: "time"},
-							&influxql.VarRef{Val: "HOUR"},
 						},
 					},
 					RHS: &influxql.IntegerLiteral{Val: 14},
@@ -793,7 +793,7 @@ func TestParser_ParseStatement(t *testing.T) {
 
 		// date_part with minute
 		{
-			s: `SELECT value FROM myseries WHERE date_part(time, MINUTE) = 30`,
+			s: `SELECT value FROM myseries WHERE date_part('minute', time) = 30`,
 			stmt: &influxql.SelectStatement{
 				IsRawQuery: true,
 				Sources:    []influxql.Source{&influxql.Measurement{Name: "myseries"}},
@@ -805,8 +805,8 @@ func TestParser_ParseStatement(t *testing.T) {
 					LHS: &influxql.Call{
 						Name: "date_part",
 						Args: []influxql.Expr{
+							&influxql.StringLiteral{Val: "minute"},
 							&influxql.VarRef{Val: "time"},
-							&influxql.VarRef{Val: "MINUTE"},
 						},
 					},
 					RHS: &influxql.IntegerLiteral{Val: 30},
@@ -816,7 +816,7 @@ func TestParser_ParseStatement(t *testing.T) {
 
 		// date_part with second
 		{
-			s: `SELECT value FROM myseries WHERE date_part(time, SECOND) < 60`,
+			s: `SELECT value FROM myseries WHERE date_part('second', time) < 60`,
 			stmt: &influxql.SelectStatement{
 				IsRawQuery: true,
 				Sources:    []influxql.Source{&influxql.Measurement{Name: "myseries"}},
@@ -828,8 +828,8 @@ func TestParser_ParseStatement(t *testing.T) {
 					LHS: &influxql.Call{
 						Name: "date_part",
 						Args: []influxql.Expr{
+							&influxql.StringLiteral{Val: "second"},
 							&influxql.VarRef{Val: "time"},
-							&influxql.VarRef{Val: "SECOND"},
 						},
 					},
 					RHS: &influxql.IntegerLiteral{Val: 60},
@@ -839,7 +839,7 @@ func TestParser_ParseStatement(t *testing.T) {
 
 		// date_part with millisecond
 		{
-			s: `SELECT value FROM myseries WHERE date_part(time, MILLISECOND) > 0`,
+			s: `SELECT value FROM myseries WHERE date_part('millisecond', time) > 0`,
 			stmt: &influxql.SelectStatement{
 				IsRawQuery: true,
 				Sources:    []influxql.Source{&influxql.Measurement{Name: "myseries"}},
@@ -851,8 +851,8 @@ func TestParser_ParseStatement(t *testing.T) {
 					LHS: &influxql.Call{
 						Name: "date_part",
 						Args: []influxql.Expr{
+							&influxql.StringLiteral{Val: "millisecond"},
 							&influxql.VarRef{Val: "time"},
-							&influxql.VarRef{Val: "MILLISECOND"},
 						},
 					},
 					RHS: &influxql.IntegerLiteral{Val: 0},
@@ -862,7 +862,7 @@ func TestParser_ParseStatement(t *testing.T) {
 
 		// date_part with microsecond
 		{
-			s: `SELECT value FROM myseries WHERE date_part(time, MICROSECOND) > 0`,
+			s: `SELECT value FROM myseries WHERE date_part('microsecond', time) > 0`,
 			stmt: &influxql.SelectStatement{
 				IsRawQuery: true,
 				Sources:    []influxql.Source{&influxql.Measurement{Name: "myseries"}},
@@ -874,8 +874,8 @@ func TestParser_ParseStatement(t *testing.T) {
 					LHS: &influxql.Call{
 						Name: "date_part",
 						Args: []influxql.Expr{
+							&influxql.StringLiteral{Val: "microsecond"},
 							&influxql.VarRef{Val: "time"},
-							&influxql.VarRef{Val: "MICROSECOND"},
 						},
 					},
 					RHS: &influxql.IntegerLiteral{Val: 0},
@@ -885,7 +885,7 @@ func TestParser_ParseStatement(t *testing.T) {
 
 		// date_part with nanosecond
 		{
-			s: `SELECT value FROM myseries WHERE date_part(time, NANOSECOND) > 0`,
+			s: `SELECT value FROM myseries WHERE date_part('nanosecond', time) > 0`,
 			stmt: &influxql.SelectStatement{
 				IsRawQuery: true,
 				Sources:    []influxql.Source{&influxql.Measurement{Name: "myseries"}},
@@ -897,8 +897,8 @@ func TestParser_ParseStatement(t *testing.T) {
 					LHS: &influxql.Call{
 						Name: "date_part",
 						Args: []influxql.Expr{
+							&influxql.StringLiteral{Val: "nanosecond"},
 							&influxql.VarRef{Val: "time"},
-							&influxql.VarRef{Val: "NANOSECOND"},
 						},
 					},
 					RHS: &influxql.IntegerLiteral{Val: 0},
@@ -908,7 +908,7 @@ func TestParser_ParseStatement(t *testing.T) {
 
 		// date_part with doy (day of year)
 		{
-			s: `SELECT value FROM myseries WHERE date_part(time, DOY) <= 365`,
+			s: `SELECT value FROM myseries WHERE date_part('doy', time) <= 365`,
 			stmt: &influxql.SelectStatement{
 				IsRawQuery: true,
 				Sources:    []influxql.Source{&influxql.Measurement{Name: "myseries"}},
@@ -920,8 +920,8 @@ func TestParser_ParseStatement(t *testing.T) {
 					LHS: &influxql.Call{
 						Name: "date_part",
 						Args: []influxql.Expr{
+							&influxql.StringLiteral{Val: "doy"},
 							&influxql.VarRef{Val: "time"},
-							&influxql.VarRef{Val: "DOY"},
 						},
 					},
 					RHS: &influxql.IntegerLiteral{Val: 365},
@@ -931,7 +931,7 @@ func TestParser_ParseStatement(t *testing.T) {
 
 		// date_part with epoch (seconds since Unix epoch)
 		{
-			s: `SELECT value FROM myseries WHERE date_part(time, EPOCH) > 1609459200`,
+			s: `SELECT value FROM myseries WHERE date_part('epoch', time) > 1609459200`,
 			stmt: &influxql.SelectStatement{
 				IsRawQuery: true,
 				Sources:    []influxql.Source{&influxql.Measurement{Name: "myseries"}},
@@ -943,8 +943,8 @@ func TestParser_ParseStatement(t *testing.T) {
 					LHS: &influxql.Call{
 						Name: "date_part",
 						Args: []influxql.Expr{
+							&influxql.StringLiteral{Val: "epoch"},
 							&influxql.VarRef{Val: "time"},
-							&influxql.VarRef{Val: "EPOCH"},
 						},
 					},
 					RHS: &influxql.IntegerLiteral{Val: 1609459200},
@@ -954,7 +954,7 @@ func TestParser_ParseStatement(t *testing.T) {
 
 		// date_part with isodow (ISO day of week, Monday = 1)
 		{
-			s: `SELECT value FROM myseries WHERE date_part(time, ISODOW) != 5`,
+			s: `SELECT value FROM myseries WHERE date_part('isodow', time) != 5`,
 			stmt: &influxql.SelectStatement{
 				IsRawQuery: true,
 				Sources:    []influxql.Source{&influxql.Measurement{Name: "myseries"}},
@@ -966,8 +966,8 @@ func TestParser_ParseStatement(t *testing.T) {
 					LHS: &influxql.Call{
 						Name: "date_part",
 						Args: []influxql.Expr{
+							&influxql.StringLiteral{Val: "isodow"},
 							&influxql.VarRef{Val: "time"},
-							&influxql.VarRef{Val: "ISODOW"},
 						},
 					},
 					RHS: &influxql.IntegerLiteral{Val: 5},
@@ -975,27 +975,9 @@ func TestParser_ParseStatement(t *testing.T) {
 			},
 		},
 
-		// date_part in SELECT clause
-		{
-			s: `SELECT date_part(time, HOUR) FROM myseries`,
-			stmt: &influxql.SelectStatement{
-				IsRawQuery: false,
-				Sources:    []influxql.Source{&influxql.Measurement{Name: "myseries"}},
-				Fields: []*influxql.Field{
-					{Expr: &influxql.Call{
-						Name: "date_part",
-						Args: []influxql.Expr{
-							&influxql.VarRef{Val: "time"},
-							&influxql.VarRef{Val: "HOUR"},
-						},
-					}},
-				},
-			},
-		},
-
 		// Multiple date_part functions (weekday filter example)
 		{
-			s: `SELECT value FROM myseries WHERE date_part(time, DOW) != 0 AND date_part(time, DOW) != 6`,
+			s: `SELECT value FROM myseries WHERE date_part('dow', time) != 0 AND date_part('dow', time) != 6`,
 			stmt: &influxql.SelectStatement{
 				IsRawQuery: true,
 				Sources:    []influxql.Source{&influxql.Measurement{Name: "myseries"}},
@@ -1009,8 +991,8 @@ func TestParser_ParseStatement(t *testing.T) {
 						LHS: &influxql.Call{
 							Name: "date_part",
 							Args: []influxql.Expr{
+								&influxql.StringLiteral{Val: "dow"},
 								&influxql.VarRef{Val: "time"},
-								&influxql.VarRef{Val: "DOW"},
 							},
 						},
 						RHS: &influxql.IntegerLiteral{Val: 0},
@@ -1020,8 +1002,8 @@ func TestParser_ParseStatement(t *testing.T) {
 						LHS: &influxql.Call{
 							Name: "date_part",
 							Args: []influxql.Expr{
+								&influxql.StringLiteral{Val: "dow"},
 								&influxql.VarRef{Val: "time"},
-								&influxql.VarRef{Val: "DOW"},
 							},
 						},
 						RHS: &influxql.IntegerLiteral{Val: 6},


### PR DESCRIPTION
Adds tests for `date_part` to ensure that we can support it using influxql

--- 
specs for date_part

`date_part(part, expression)`

Arguments

    - part: Part of the date to return. The following date parts are supported:
       - year
        - quarter (emits value in inclusive range [1, 4] based on which quartile of the year the date is in)
        - month
        - week (week of the year)
        - day (day of the month)
        - hour
        - minute
        - second
        - millisecond
        - microsecond
        - nanosecond
        - dow (day of the week where Sunday is 0)
        - doy (day of the year)
        - epoch (seconds since Unix epoch)
        - isodow (day of the week where Monday is 0)
    - expression: Time expression to operate on. Can be a constant, column, or function.

Example usage:

```
SELECT * FROM some_measurement
WHERE time >= now() - 10d AND time <= now() AND (date_part(time, dow) != 0 AND date_part(time, dow) != 6)
```